### PR TITLE
Add check-inbox script for GitHub notifications

### DIFF
--- a/bin/check-inbox
+++ b/bin/check-inbox
@@ -37,16 +37,25 @@ end
 
 notifications = gh_api("/notifications?participating=true")
 
-notifications.each do |notif|
-  entry = {
-    reason: notif["reason"],
-    subject: notif.dig("subject", "title"),
-    type: notif.dig("subject", "type"),
-    repo: notif.dig("repository", "full_name"),
-    updated: notif["updated_at"],
-    url: subject_html_url(notif),
-    comment_url: comment_html_url(notif),
-  }
+if notifications.empty?
+  puts "No unread GitHub participating notifications."
+  exit
+end
 
-  puts JSON.generate(entry)
+puts "# GitHub Participating Notifications (#{notifications.size} unread)\n\n"
+
+notifications.each_with_index do |notif, i|
+  title = notif.dig("subject", "title")
+  type = notif.dig("subject", "type")
+  repo = notif.dig("repository", "full_name")
+  reason = notif["reason"].tr("_", " ")
+  updated = notif["updated_at"]
+  url = subject_html_url(notif)
+  comment_url = comment_html_url(notif)
+
+  link = comment_url || url
+  puts "(#{i + 1}) [#{type}] #{title}"
+  puts "Repo: #{repo} | Reason: #{reason} | Updated: #{updated}"
+  puts "URL: #{link}" if link
+  puts
 end

--- a/bin/check-inbox
+++ b/bin/check-inbox
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# Fetches unread GitHub participating notifications using `gh api`.
+
+require "json"
+require "open3"
+
+def gh_api(path)
+  stdout, stderr, status = Open3.capture3("gh", "api", path, "--paginate")
+  abort "gh api #{path} failed: #{stderr}" unless status.success?
+  JSON.parse(stdout)
+end
+
+def gh_api_silent(path)
+  stdout, _, status = Open3.capture3("gh", "api", path)
+  return nil unless status.success?
+  JSON.parse(stdout)
+rescue JSON::ParserError
+  nil
+end
+
+def subject_html_url(notif)
+  api_url = notif.dig("subject", "url")
+  return nil unless api_url
+
+  api_url
+    .gsub("https://api.github.com/repos", "https://github.com")
+    .gsub("/pulls/", "/pull/")
+end
+
+def comment_html_url(notif)
+  comment_api_url = notif.dig("subject", "latest_comment_url")
+  return nil if comment_api_url.nil? || comment_api_url.empty?
+
+  data = gh_api_silent(comment_api_url)
+  data&.fetch("html_url", nil)
+end
+
+notifications = gh_api("/notifications?participating=true")
+
+notifications.each do |notif|
+  entry = {
+    reason: notif["reason"],
+    subject: notif.dig("subject", "title"),
+    type: notif.dig("subject", "type"),
+    repo: notif.dig("repository", "full_name"),
+    updated: notif["updated_at"],
+    url: subject_html_url(notif),
+    comment_url: comment_html_url(notif),
+  }
+
+  puts JSON.generate(entry)
+end

--- a/bin/gh-inbox
+++ b/bin/gh-inbox
@@ -1,8 +1,18 @@
 #!/usr/bin/env ruby
-# Fetches unread GitHub participating notifications using `gh api`.
+# Fetches unread GitHub participating notifications.
+#
+# Setup: brew install gh && gh auth login
+# Usage: gh-inbox
+#
+# Output includes notification ID, PR/issue URL, comment URL, and actor.
+# To mark a notification as read: gh api -X PATCH /notifications/threads/{ID}
 
 require "json"
 require "open3"
+
+unless system("gh", "auth", "status", out: File::NULL, err: File::NULL)
+  abort "gh CLI not authenticated. Run: gh auth login"
+end
 
 def gh_api(path)
   stdout, stderr, status = Open3.capture3("gh", "api", path, "--paginate")
@@ -27,12 +37,27 @@ def subject_html_url(notif)
     .gsub("/pulls/", "/pull/")
 end
 
-def comment_html_url(notif)
+def resolve_comment(notif)
   comment_api_url = notif.dig("subject", "latest_comment_url")
-  return nil if comment_api_url.nil? || comment_api_url.empty?
+  return [nil, nil] if comment_api_url.nil? || comment_api_url.empty?
 
   data = gh_api_silent(comment_api_url)
-  data&.fetch("html_url", nil)
+  return [nil, nil] unless data
+
+  [data["html_url"], data.dig("user", "login")]
+end
+
+def resolve_actor(notif, comment_user)
+  return comment_user if comment_user
+
+  subject_url = notif.dig("subject", "url")
+  return nil unless subject_url
+
+  reason = notif["reason"]
+  if reason == "review_requested" || reason == "author"
+    data = gh_api_silent(subject_url)
+    data&.dig("user", "login")
+  end
 end
 
 notifications = gh_api("/notifications?participating=true")
@@ -51,13 +76,15 @@ notifications.each_with_index do |notif, i|
   reason = notif["reason"].tr("_", " ")
   updated = notif["updated_at"]
   url = subject_html_url(notif)
-  comment_url = comment_html_url(notif)
+  comment_url, comment_user = resolve_comment(notif)
+  actor = resolve_actor(notif, comment_user)
   link = comment_url || url
 
   puts "---" unless i.zero?
   puts "[#{type}] #{title}"
   puts "ID: #{notif["id"]}"
   puts "Repo: #{repo}"
+  puts "From: #{actor}" if actor
   puts "Reason: #{reason}"
   puts "Updated: #{updated}"
   puts "URL: #{link}" if link

--- a/bin/gh-inbox
+++ b/bin/gh-inbox
@@ -46,16 +46,19 @@ puts "# GitHub Participating Notifications (#{notifications.size} unread)\n\n"
 
 notifications.each_with_index do |notif, i|
   title = notif.dig("subject", "title")
-  type = notif.dig("subject", "type")
+  type = notif.dig("subject", "type").then { |t| t == "PullRequest" ? "PR" : t }
   repo = notif.dig("repository", "full_name")
   reason = notif["reason"].tr("_", " ")
   updated = notif["updated_at"]
   url = subject_html_url(notif)
   comment_url = comment_html_url(notif)
-
   link = comment_url || url
-  puts "(#{i + 1}) [#{type}] #{title}"
-  puts "Repo: #{repo} | Reason: #{reason} | Updated: #{updated}"
+
+  puts "---" unless i.zero?
+  puts "[#{type}] #{title}"
+  puts "ID: #{notif["id"]}"
+  puts "Repo: #{repo}"
+  puts "Reason: #{reason}"
+  puts "Updated: #{updated}"
   puts "URL: #{link}" if link
-  puts
 end

--- a/bin/jira-inbox
+++ b/bin/jira-inbox
@@ -16,6 +16,28 @@ JIRA_BASE_URL = "https://zipline.atlassian.net"
 JIRA_EMAIL = "alex.musayev@zipline.inc"
 JIRA_TOKEN = ENV.fetch("JIRA_API_TOKEN") { abort "JIRA_API_TOKEN not set. See: https://id.atlassian.net/manage-profile/security/api-tokens" }
 
+def jira_get(uri)
+  req = Net::HTTP::Get.new(uri)
+  req.basic_auth(JIRA_EMAIL, JIRA_TOKEN)
+  req["Accept"] = "application/json"
+  Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+end
+
+def verify_auth!
+  uri = URI("#{JIRA_BASE_URL}/rest/api/3/myself")
+  res = jira_get(uri)
+  case res
+  when Net::HTTPUnauthorized
+    abort "JIRA_API_TOKEN is invalid or expired. Generate a new one: https://id.atlassian.net/manage-profile/security/api-tokens"
+  when Net::HTTPForbidden
+    abort "JIRA_API_TOKEN lacks permission. Check token scopes: https://id.atlassian.net/manage-profile/security/api-tokens"
+  when Net::HTTPSuccess
+    # ok
+  else
+    abort "Jira auth check failed (HTTP #{res.code}): #{res.body}"
+  end
+end
+
 def jira_search(jql)
   uri = URI("#{JIRA_BASE_URL}/rest/api/3/search/jql")
   uri.query = URI.encode_www_form(
@@ -24,12 +46,8 @@ def jira_search(jql)
     maxResults: 100
   )
 
-  req = Net::HTTP::Get.new(uri)
-  req.basic_auth(JIRA_EMAIL, JIRA_TOKEN)
-  req["Accept"] = "application/json"
-
-  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
-  abort "Jira API error: #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+  res = jira_get(uri)
+  abort "Jira API error (HTTP #{res.code}): #{res.body}" unless res.is_a?(Net::HTTPSuccess)
 
   JSON.parse(res.body)["issues"].map do |item|
     f = item["fields"]
@@ -44,6 +62,8 @@ def jira_search(jql)
     }
   end
 end
+
+verify_auth!
 
 assigned = jira_search("assignee = currentUser() AND resolution = Unresolved")
 watched = jira_search("watcher = currentUser() AND updated >= -7d AND resolution = Unresolved")

--- a/bin/jira-inbox
+++ b/bin/jira-inbox
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# Fetches Jira issues requiring attention via the Jira REST API.
+#
+# Setup: export JIRA_API_TOKEN=... (Atlassian API token from https://id.atlassian.net/manage-profile/security/api-tokens)
+# Usage: jira-inbox
+#
+# Shows two sections:
+#   1. Assigned to me (unresolved)
+#   2. Watching (updated in the last 7 days, unresolved)
+
+require "net/http"
+require "uri"
+require "json"
+
+JIRA_BASE_URL = "https://zipline.atlassian.net"
+JIRA_EMAIL = "alex.musayev@zipline.inc"
+JIRA_TOKEN = ENV.fetch("JIRA_API_TOKEN") { abort "JIRA_API_TOKEN not set. See: https://id.atlassian.net/manage-profile/security/api-tokens" }
+
+def jira_search(jql)
+  uri = URI("#{JIRA_BASE_URL}/rest/api/3/search/jql")
+  uri.query = URI.encode_www_form(
+    jql: jql,
+    fields: "issuetype,summary,status,assignee,reporter,priority",
+    maxResults: 100
+  )
+
+  req = Net::HTTP::Get.new(uri)
+  req.basic_auth(JIRA_EMAIL, JIRA_TOKEN)
+  req["Accept"] = "application/json"
+
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(req) }
+  abort "Jira API error: #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+
+  JSON.parse(res.body)["issues"].map do |item|
+    f = item["fields"]
+    {
+      type: f.dig("issuetype", "name"),
+      key: item["key"],
+      summary: f["summary"],
+      status: f.dig("status", "name"),
+      assignee: f.dig("assignee", "displayName"),
+      reporter: f.dig("reporter", "displayName"),
+      priority: f.dig("priority", "name"),
+    }
+  end
+end
+
+assigned = jira_search("assignee = currentUser() AND resolution = Unresolved")
+watched = jira_search("watcher = currentUser() AND updated >= -7d AND resolution = Unresolved")
+
+# Deduplicate by key, assigned takes precedence
+by_key = {}
+assigned.each { |i| by_key[i[:key]] = i.merge(section: "assigned") }
+watched.each { |i| by_key[i[:key]] ||= i.merge(section: "watching") }
+
+issues = by_key.values
+
+if issues.empty?
+  puts "No Jira issues requiring attention."
+  exit
+end
+
+assigned_issues = issues.select { |i| i[:section] == "assigned" }
+watched_issues = issues.select { |i| i[:section] == "watching" }
+
+puts "# Jira Inbox (#{issues.size} issues)\n\n"
+
+[["Assigned to me", assigned_issues], ["Watching (updated last 7 days)", watched_issues]].each do |label, group|
+  next if group.empty?
+
+  puts "## #{label} (#{group.size})\n\n"
+
+  group.each_with_index do |issue, i|
+    puts "---" unless i.zero?
+    puts "[#{issue[:type]}] #{issue[:summary]}"
+    puts "Key: #{issue[:key]}"
+    puts "Status: #{issue[:status]}"
+    puts "Priority: #{issue[:priority]}" unless issue[:priority].to_s.empty?
+    puts "Assignee: #{issue[:assignee]}" unless issue[:assignee].to_s.empty?
+    puts "Reporter: #{issue[:reporter]}" unless issue[:reporter].to_s.empty?
+    puts "URL: #{JIRA_BASE_URL}/browse/#{issue[:key]}"
+  end
+
+  puts
+end


### PR DESCRIPTION
Fetches unread GitHub participating notifications using the gh API.

Converts the raw GitHub notification API response to structured JSON output with resolved URLs for both issue/PR links and comment links. Each notification is output as a single JSON line with reason, subject, type, repo, updated timestamp, and URL fields.

Uses Open3 for cleaner shell integration and respects gh's existing auth and pagination.