### PR TITLE
Extend today command to include manual tasks from daily todo note

### DIFF
--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -154,7 +154,9 @@ gh api repos/<owner>/<repo>/issues/<number>/comments
 
 If multiple signals apply, show the highest-priority one.
 
-## Phase 2: Synthesize the Todo List
+## Phase 2: Deduplicate and Synthesize the Todo List
+
+**Deduplication**: When a todo note task overlaps with a source-derived item (e.g., a todo note task references the same PR that was also found in GitHub notifications), merge them into a single item. Use the richer context from the source-derived data, but keep `source: todo_note` to indicate it was explicitly tracked. Deduplicate before prioritizing.
 
 Produce a **flat prioritized list** of tasks. Each item should be a collapsible `<details open>` block (expanded by default).
 
@@ -216,11 +218,7 @@ After the todo list, add a **collapsed** `<details>` section (NOT expanded) list
 
 Format: one resource per line, `<linked id> — short description`.
 
-## Phase 4: Deduplication
-
-When a todo note task overlaps with a source-derived item (e.g., a todo note task references the same PR that was also found in GitHub notifications), merge them into a single item. Use the richer context from the source-derived data, but keep `source: todo_note` to indicate it was explicitly tracked.
-
-## Phase 5: Save as YAML
+## Phase 4: Save as YAML
 
 Generate a UUID7 for each todo item:
 

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -26,7 +26,7 @@ Parse all task lines (`- [ ]`, `- [+]`, `- [>]`).
 
 Categorize each open task:
 
-- **Work tasks**: anything related to code, PRs, Jira, reviews, deploys, team syncs, EOD, or work-related activities. The `[daily]` tag indicates a recurring work task.
+- **Work tasks**: anything related to code, PRs, Jira, reviews, deploys, team syncs, EOD, or work-related activities.
 - **Personal tasks**: items tagged `[Private]` or clearly unrelated to work (billing, personal errands, etc.).
 
 **Include all tasks** — both work and personal. Personal tasks are classified with `category: personal` in the YAML.
@@ -149,7 +149,7 @@ gh api repos/<owner>/<repo>/issues/<number>/comments
 
 ```html
 <details open>
-<summary><strong>1. Review <a href="...">#123</a></strong> · <code>SOLE_REVIEWER</code> — jdoe: Fix tooltip alignment on dashboard widgets</summary>
+<summary><strong>1. Review <a href="...">123</a></strong> · <code>SOLE_REVIEWER</code> — jdoe: Fix tooltip alignment on dashboard widgets</summary>
 ```
 
 If multiple signals apply, show the highest-priority one.
@@ -167,17 +167,16 @@ Produce a **flat prioritized list** of tasks. Each item should be a collapsible 
 5. **Active feedback on my PRs** — comments needing response
 6. **My PRs ready to merge** — approved, just need the merge button
 7. **Team review requests** — `TEAM_REQUEST`, shared responsibility
-8. **Manual tasks from todo note** — work tasks from the daily todo note (non-recurring, non-`[daily]`)
+8. **Tasks from todo note** — work tasks from the daily todo note
 9. **In-progress Jira work** — tickets I'm actively working on
 10. **Awareness items** — things happening that affect my work (upgrades, team decisions)
-11. **Recurring tasks** — EOD report, team sync prep, etc. (includes `[daily]` items from todo note)
-12. **Personal tasks** — `category: personal` items from the todo note
+11. **Personal tasks** — `category: personal` items from the todo note
 
 ### Format for each item
 
 ```html
 <details open>
-<summary><strong>N. Action verb <a href="URL">#NUMBER</a></strong> · <code>SIGNAL_TAG</code> — Author/context: Short title</summary>
+<summary><strong>N. Action verb <a href="URL">NUMBER</a></strong> · <code>SIGNAL_TAG</code> — Author/context: Short title</summary>
 
 1-2 sentences of context. What specifically needs doing and why.
 </details>
@@ -189,7 +188,7 @@ For items originating from the todo note, add a `· <code>TODO</code>` badge in 
 
 ### Linking rules
 
-- PRs: `[#NUMBER](url)` or inline `<a href="url">#NUMBER</a>` in summary
+- PRs: `[NUMBER](url)` or inline `<a href="url">NUMBER</a>` in summary
 - Jira: `[PROJECT-NNNN](https://org.atlassian.net/browse/PROJECT-NNNN)`
 - Keep descriptions concise — this is a scannable list, not a report
 
@@ -210,25 +209,16 @@ Include **all** GitHub usernames found in the todo text — PR authors, reviewer
 After the todo list, add a **collapsed** `<details>` section (NOT expanded) listing every resource you processed:
 
 - The todo note (UID and count of work/personal/completed tasks)
-- Every PR you read (with linked number and short description)
+- Every PR you read (with linked PR number and short description)
 - Every Slack channel/DM/search you read
 - Every Jira ticket from the inbox
 - GitHub notifications summary
 
 Format: one resource per line, `<linked id> — short description`.
 
-## Phase 4: Known/Expected Tasks
+## Phase 4: Deduplication
 
-Always include these recurring items at the bottom of the todo list (lower priority unless sources reveal urgency):
-
-- Do code reviews
-- Follow up on active PR feedback
-- Prep status update for team sync
-- Write EOD report for Slack
-
-These may be merged with source-derived items when they overlap (e.g., specific PRs needing review replace the generic "do code reviews" item).
-
-**`[daily]` tasks from the todo note** (e.g., `[daily] Github notifications`, `[daily] Jira`) map naturally to these recurring items or to source-gathering activities. Merge them — do not create duplicate entries. Use `source: todo_note` for merged items where the todo note was the origin.
+When a todo note task overlaps with a source-derived item (e.g., a todo note task references the same PR that was also found in GitHub notifications), merge them into a single item. Use the richer context from the source-derived data, but keep `source: todo_note` to indicate it was explicitly tracked.
 
 ## Phase 5: Save as YAML
 
@@ -268,7 +258,7 @@ todos:
       pr: "https://github.com/org/project/pull/1"
       jira: "https://org.atlassian.net/browse/PROJECT-NNNN"  # if applicable
     refs_map:
-      "#1": "https://github.com/org/project/pull/1"
+      "1": "https://github.com/org/project/pull/1"
       "PROJECT-NNNN": "https://org.atlassian.net/browse/PROJECT-NNNN"
     usernames_map:
       "jdoe": "https://github.com/jdoe"
@@ -287,7 +277,7 @@ sources:
     personal_tasks: 1
     completed_tasks: 3
   github_prs:
-    - ref: "#123"
+    - ref: "123"
       url: "https://github.com/org/project/pull/123"
       description: "Fix tooltip alignment on dashboard widgets"
     # ...

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -8,15 +8,13 @@ Aggregate an easy-to-read flat prioritized todo list for today, based on the mos
 
 ### 0a. Ensure today's todo note exists
 
-Run `new-todo` to create today's todo note (safe — returns existing path if already created):
+Run `new-todo` to ensure today's todo note exists (idempotent — returns the existing path without overwriting):
 
 ```bash
-TODO_PATH=$(new-todo)
+new-todo
 ```
 
-### 0b. Read and categorize todo tasks
-
-Read the todo note at `$TODO_PATH`. Parse all task lines (`- [ ]`, `- [+]`, `- [>]`).
+Then read today's todo note. The path follows the pattern `$NOTES_PATH/YYYY/MM/YYYYMMDD_*_todo.md` where the date matches today. Parse all task lines (`- [ ]`, `- [+]`, `- [>]`).
 
 **Skip completed (`[+]`) and moved (`[>]`) tasks** — only process open (`[ ]`) tasks.
 

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -6,19 +6,25 @@ Aggregate an easy-to-read flat prioritized todo list for today, based on the mos
 
 ## Phase 0: Context Note + Todo Note
 
-### 0a. Context Note (Optional)
+### 0a. Context Note
 
 If an argument was provided, it is a **notes UID** (e.g. `20260309_9174`) referencing a context note with background information for today's work.
 
-Find and read the note:
+If no argument was provided, use the default slug `dailies-context` — find the most recent note with this slug:
 
 ```bash
-notes read $ARGUMENT
+notes read dailies-context
+```
+
+If the note is not found, skip this step entirely.
+
+If a UID or default note was found, read it:
+
+```bash
+notes read $ARGUMENT  # or the resolved UID
 ```
 
 Use its content as additional context when prioritizing and synthesizing the todo list. Do NOT include raw context note content in the output — use it to inform priorities and fill gaps.
-
-If no argument was provided, skip this step.
 
 ### 0b. Ensure today's todo note exists
 
@@ -62,7 +68,7 @@ Categorize each open task:
 
 **Personal tasks** — only enrich if the context/origin is clearly understood (e.g. a URL in the task text). Otherwise lift the task text as-is into `title` and leave `context` empty or minimal.
 
-All tasks from the todo note use `source: todo_note` in the YAML. Work tasks use `category: work` (default, can be omitted). Personal tasks use `category: personal`.
+All tasks from the todo note use `source: todo_note` in the YAML. Work tasks use `category: work`. Personal tasks use `category: personal`. Always set `category` explicitly — undefined is treated as personal.
 
 ## Phase 1: Gather Sources (in parallel where possible)
 
@@ -102,10 +108,12 @@ For each PR that is `review_requested` from me or authored by me: fetch title, a
 
 ### 1c. Slack
 
+**Prerequisite**: This step requires a Slack user ID. If the context note provides one, use it. If not and the Slack MCP tools cannot resolve the current user's ID, skip all Slack searches.
+
 Use Slack MCP tools to search:
 
 1. `to:me after:<yesterday>` — DMs and mentions
-2. `<@MY_SLACK_ID> after:<2 days ago>` — broader mentions
+2. `<@SLACK_USER_ID> after:<2 days ago>` — broader mentions
 3. Read the project team channel (`#project-team`) for today's messages
 4. Read the team channel (`#team-updates`) for recent updates
 5. Read `#dev-general` for today's messages
@@ -184,7 +192,7 @@ Produce a **flat prioritized list** of tasks. Each item should be a collapsible 
 </details>
 ```
 
-The `· <code>SIGNAL_TAG</code>` part is only included for GitHub PR items that have a classified signal. Non-PR items (Jira work, recurring tasks, etc.) omit it.
+The `· <code>SIGNAL_TAG</code>` part is only included for GitHub PR items that have a classified signal. Non-PR items (Jira work, todo note tasks, etc.) omit it.
 
 For items originating from the todo note, add a `· <code>TODO</code>` badge in the summary line (same position as `SIGNAL_TAG`). If a todo note task also has a PR signal (e.g., a task with a PR URL that maps to a `SOLE_REVIEWER` signal), show the PR signal instead — it's more informative. The `TODO` badge is only for tasks that have no other signal.
 
@@ -249,7 +257,7 @@ todos:
     priority: high  # enum: high, medium, low
     signal: sole_reviewer  # enum: sole_reviewer, author_replied, mentioned, direct_request, team_request, subscribed (omit for non-PR items)
     source: github  # enum: github, jira, slack, todo_note (omit or use most specific source when task comes from multiple)
-    # category omitted — defaults to work
+    category: work  # enum: work, personal (always set explicitly — undefined is treated as personal)
     blocking: ["jdoe"]  # GitHub usernames of people waiting on me
     refs:
       pr: "https://github.com/org/project/pull/123"
@@ -264,7 +272,7 @@ todos:
     title: "Finish API migration for PROJECT-1234"
     priority: medium
     source: todo_note
-    # category omitted — defaults to work
+    category: work
     refs:
       jira: "https://org.atlassian.net/browse/PROJECT-1234"
     refs_map:
@@ -276,7 +284,7 @@ todos:
     title: "Renew gym membership"
     priority: low
     source: todo_note
-    category: personal  # enum: work, personal (omit for work — it's the default)
+    category: personal
     context: "Expires end of week."
 
 sources:

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -8,13 +8,19 @@ Aggregate an easy-to-read flat prioritized todo list for today, based on the mos
 
 ### 0a. Ensure today's todo note exists
 
-Run `new-todo` to ensure today's todo note exists (idempotent — returns the existing path without overwriting):
+Create today's todo note if missing (idempotent — skips if already exists, carries over pending tasks from previous day):
 
 ```bash
-new-todo
+notes new-todo
 ```
 
-Then read today's todo note. The path follows the pattern `$NOTES_PATH/YYYY/MM/YYYYMMDD_*_todo.md` where the date matches today. Parse all task lines (`- [ ]`, `- [+]`, `- [>]`).
+Then read it:
+
+```bash
+notes read todo
+```
+
+Parse all task lines (`- [ ]`, `- [+]`, `- [>]`).
 
 **Skip completed (`[+]`) and moved (`[>]`) tasks** — only process open (`[ ]`) tasks.
 
@@ -203,7 +209,7 @@ Include **all** GitHub usernames found in the todo text — PR authors, reviewer
 
 After the todo list, add a **collapsed** `<details>` section (NOT expanded) listing every resource you processed:
 
-- The todo note (path and count of work/personal/completed tasks)
+- The todo note (UID and count of work/personal/completed tasks)
 - Every PR you read (with linked number and short description)
 - Every Slack channel/DM/search you read
 - Every Jira ticket from the inbox
@@ -276,7 +282,7 @@ todos:
 
 sources:
   todo_note:
-    path: "/Users/alex/Dropbox/Notes/2026/03/20260311_9200_todo.md"
+    uid: "20260311_9200"
     work_tasks: 8
     personal_tasks: 1
     completed_tasks: 3

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -4,9 +4,23 @@ description: "Aggregate a prioritized daily todo from Slack, Jira, GitHub PRs, a
 
 Aggregate an easy-to-read flat prioritized todo list for today, based on the most recent context from all available sources.
 
-## Phase 0: Todo Note + Context Note
+## Phase 0: Context Note + Todo Note
 
-### 0a. Ensure today's todo note exists
+### 0a. Context Note (Optional)
+
+If an argument was provided, it is a **notes UID** (e.g. `20260309_9174`) referencing a context note with background information for today's work.
+
+Find and read the note:
+
+```bash
+notes read $ARGUMENT
+```
+
+Use its content as additional context when prioritizing and synthesizing the todo list. Do NOT include raw context note content in the output — use it to inform priorities and fill gaps.
+
+If no argument was provided, skip this step.
+
+### 0b. Ensure today's todo note exists
 
 Create today's todo note if missing (idempotent — skips if already exists, carries over pending tasks from previous day):
 
@@ -49,20 +63,6 @@ Categorize each open task:
 **Personal tasks** — only enrich if the context/origin is clearly understood (e.g. a URL in the task text). Otherwise lift the task text as-is into `title` and leave `context` empty or minimal.
 
 All tasks from the todo note use `source: todo_note` in the YAML. Work tasks use `category: work` (default, can be omitted). Personal tasks use `category: personal`.
-
-### 0d. Context Note (Optional)
-
-If an argument was provided, it is a **notes UID** (e.g. `20260309_9174`) referencing a context note with background information for today's work.
-
-Find and read the note:
-
-```bash
-notes read $ARGUMENT
-```
-
-Use its content as additional context when prioritizing and synthesizing the todo list. Do NOT include raw context note content in the output — use it to inform priorities and fill gaps.
-
-If no argument was provided, skip this step.
 
 ## Phase 1: Gather Sources (in parallel where possible)
 
@@ -251,7 +251,7 @@ todos:
     title: "Fix tooltip alignment on dashboard widgets"
     priority: high  # enum: high, medium, low
     signal: sole_reviewer  # enum: sole_reviewer, author_replied, mentioned, direct_request, team_request, subscribed (omit for non-PR items)
-    source: todo_note  # enum: github, jira, slack, todo_note, recurring (omit or use most specific source when task comes from multiple)
+    source: todo_note  # enum: github, jira, slack, todo_note (omit or use most specific source when task comes from multiple)
     category: personal  # enum: work, personal (omit for work — it's the default)
     blocking: ["jdoe"]  # GitHub usernames of people waiting on me
     refs:

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -8,21 +8,11 @@ Aggregate an easy-to-read flat prioritized todo list for today, based on the mos
 
 ### 0a. Context Note
 
-If an argument was provided, it is a **notes UID** (e.g. `20260309_9174`) referencing a context note with background information for today's work.
-
-If no argument was provided, use the default slug `today-context` — find the most recent note with this slug:
-
 ```bash
-notes read today-context
+notes read ${ARGUMENT:-today-context}
 ```
 
-If the note is not found, skip this step entirely.
-
-If a UID or default note was found, read it:
-
-```bash
-notes read $ARGUMENT  # or the resolved UID
-```
+Read the context note — either the argument (UID or slug) or `today-context` by default. If the note is not found, skip this step (not an error).
 
 Use its content as additional context when prioritizing and synthesizing the todo list. Do NOT include raw context note content in the output — use it to inform priorities and fill gaps.
 

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -4,7 +4,49 @@ description: "Aggregate a prioritized daily todo from Slack, Jira, GitHub PRs, a
 
 Aggregate an easy-to-read flat prioritized todo list for today, based on the most recent context from all available sources.
 
-## Phase 0: Context Note (Optional)
+## Phase 0: Todo Note + Context Note
+
+### 0a. Ensure today's todo note exists
+
+Run `new-todo` to create today's todo note (safe — returns existing path if already created):
+
+```bash
+TODO_PATH=$(new-todo)
+```
+
+### 0b. Read and categorize todo tasks
+
+Read the todo note at `$TODO_PATH`. Parse all task lines (`- [ ]`, `- [+]`, `- [>]`).
+
+**Skip completed (`[+]`) and moved (`[>]`) tasks** — only process open (`[ ]`) tasks.
+
+Categorize each open task:
+
+- **Work tasks**: anything related to code, PRs, Jira, reviews, deploys, team syncs, EOD, or work-related activities. The `[daily]` tag indicates a recurring work task.
+- **Personal tasks**: items tagged `[Private]` or clearly unrelated to work (billing, personal errands, etc.).
+
+**Include all tasks** — both work and personal. Personal tasks are classified with `category: personal` in the YAML.
+
+### 0c. Enrich todo note tasks
+
+**Work tasks** — enrich with external context:
+
+1. **Extract references** — find GitHub PR URLs, Jira ticket IDs, note UIDs (e.g. `[20260313_9235]`) in the task text.
+2. **Fetch context for GitHub URLs** — for each PR URL found, run:
+   ```bash
+   gh pr view <number> --repo <owner>/<repo> --json title,author,url,state,reviewDecision,additions,deletions,isDraft
+   ```
+3. **Fetch context for note UIDs** — for each `[YYYYMMDD_NNNN]` reference, run:
+   ```bash
+   notes read <UID>
+   ```
+4. **Keep the task concise** — use fetched context to write a better `context` field in the YAML, but do not bloat the task. Match the shape/length of other todo items.
+
+**Personal tasks** — only enrich if the context/origin is clearly understood (e.g. a URL in the task text). Otherwise lift the task text as-is into `title` and leave `context` empty or minimal.
+
+All tasks from the todo note use `source: todo_note` in the YAML. Work tasks use `category: work` (default, can be omitted). Personal tasks use `category: personal`.
+
+### 0d. Context Note (Optional)
 
 If an argument was provided, it is a **notes UID** (e.g. `20260309_9174`) referencing a context note with background information for today's work.
 
@@ -121,9 +163,11 @@ Produce a **flat prioritized list** of tasks. Each item should be a collapsible 
 5. **Active feedback on my PRs** — comments needing response
 6. **My PRs ready to merge** — approved, just need the merge button
 7. **Team review requests** — `TEAM_REQUEST`, shared responsibility
-8. **In-progress Jira work** — tickets I'm actively working on
-9. **Awareness items** — things happening that affect my work (upgrades, team decisions)
-10. **Recurring tasks** — EOD report, team sync prep, etc.
+8. **Manual tasks from todo note** — work tasks from the daily todo note (non-recurring, non-`[daily]`)
+9. **In-progress Jira work** — tickets I'm actively working on
+10. **Awareness items** — things happening that affect my work (upgrades, team decisions)
+11. **Recurring tasks** — EOD report, team sync prep, etc. (includes `[daily]` items from todo note)
+12. **Personal tasks** — `category: personal` items from the todo note
 
 ### Format for each item
 
@@ -137,16 +181,31 @@ Produce a **flat prioritized list** of tasks. Each item should be a collapsible 
 
 The `· <code>SIGNAL_TAG</code>` part is only included for GitHub PR items that have a classified signal. Non-PR items (Jira work, recurring tasks, etc.) omit it.
 
+For items originating from the todo note, add a `· <code>TODO</code>` badge in the summary line (same position as `SIGNAL_TAG`). If a todo note task also has a PR signal (e.g., a task with a PR URL that maps to a `SOLE_REVIEWER` signal), show the PR signal instead — it's more informative. The `TODO` badge is only for tasks that have no other signal.
+
 ### Linking rules
 
 - PRs: `[#NUMBER](url)` or inline `<a href="url">#NUMBER</a>` in summary
 - Jira: `[PROJECT-NNNN](https://org.atlassian.net/browse/PROJECT-NNNN)`
 - Keep descriptions concise — this is a scannable list, not a report
 
+### Username mapping rules
+
+For each todo item, collect **every GitHub username** mentioned anywhere in its `title`, `context`, or `blocking` fields — regardless of whether the username appears with an `@` prefix or not. Map each to its GitHub profile URL in a `usernames_map` dictionary on the todo item. Keys are bare usernames (no `@` prefix):
+
+```yaml
+usernames_map:
+  "jdoe": "https://github.com/jdoe"
+  "asmith": "https://github.com/asmith"
+```
+
+Include **all** GitHub usernames found in the todo text — PR authors, reviewers, people mentioned in discussion, blocking users, etc. When unsure whether a name is a GitHub username, include it if it was obtained from GitHub data (PR author, reviewer, commenter).
+
 ## Phase 3: Processed Sources Reference
 
 After the todo list, add a **collapsed** `<details>` section (NOT expanded) listing every resource you processed:
 
+- The todo note (path and count of work/personal/completed tasks)
 - Every PR you read (with linked number and short description)
 - Every Slack channel/DM/search you read
 - Every Jira ticket from the inbox
@@ -164,6 +223,8 @@ Always include these recurring items at the bottom of the todo list (lower prior
 - Write EOD report for Slack
 
 These may be merged with source-derived items when they overlap (e.g., specific PRs needing review replace the generic "do code reviews" item).
+
+**`[daily]` tasks from the todo note** (e.g., `[daily] Github notifications`, `[daily] Jira`) map naturally to these recurring items or to source-gathering activities. Merge them — do not create duplicate entries. Use `source: todo_note` for merged items where the todo note was the origin.
 
 ## Phase 5: Save as YAML
 
@@ -196,10 +257,17 @@ todos:
     title: "Fix tooltip alignment on dashboard widgets"
     priority: high  # enum: high, medium, low
     signal: sole_reviewer  # enum: sole_reviewer, author_replied, mentioned, direct_request, team_request, subscribed (omit for non-PR items)
+    source: todo_note  # enum: github, jira, slack, todo_note, recurring (omit or use most specific source when task comes from multiple)
+    category: personal  # enum: work, personal (omit for work — it's the default)
     blocking: ["jdoe"]  # GitHub usernames of people waiting on me
     refs:
       pr: "https://github.com/org/project/pull/1"
       jira: "https://org.atlassian.net/browse/PROJECT-NNNN"  # if applicable
+    refs_map:
+      "#1": "https://github.com/org/project/pull/1"
+      "PROJECT-NNNN": "https://org.atlassian.net/browse/PROJECT-NNNN"
+    usernames_map:
+      "jdoe": "https://github.com/jdoe"
     context: "Small bugfix (22+/1-), no reviews yet. jdoe is blocked."
 
   - id: "019cdd2f-c8a2-7123-abcd-1234567890ab"
@@ -209,6 +277,11 @@ todos:
     # ... etc
 
 sources:
+  todo_note:
+    path: "/Users/alex/Dropbox/Notes/2026/03/20260311_9200_todo.md"
+    work_tasks: 8
+    personal_tasks: 1
+    completed_tasks: 3
   github_prs:
     - ref: "#123"
       url: "https://github.com/org/project/pull/123"

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -10,10 +10,10 @@ Aggregate an easy-to-read flat prioritized todo list for today, based on the mos
 
 If an argument was provided, it is a **notes UID** (e.g. `20260309_9174`) referencing a context note with background information for today's work.
 
-If no argument was provided, use the default slug `dailies-context` — find the most recent note with this slug:
+If no argument was provided, use the default slug `today-context` — find the most recent note with this slug:
 
 ```bash
-notes read dailies-context
+notes read today-context
 ```
 
 If the note is not found, skip this step entirely.

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -244,7 +244,6 @@ sources_processed: <total count of items scanned>
 
 todos:
   - id: "019cdd2f-b695-7741-9dcb-aaefae886552"  # UUID7, sortable
-    position: 1
     action: review  # enum: review, respond, merge, write, awareness, prep
     title: "Fix tooltip alignment on dashboard widgets"
     priority: high  # enum: high, medium, low
@@ -261,7 +260,6 @@ todos:
     context: "Small bugfix (22+/1-), no other reviewers. jdoe is blocked."
 
   - id: "019cdd2f-c8a2-7123-abcd-1234567890ab"
-    position: 2
     action: write
     title: "Finish API migration for PROJECT-1234"
     priority: medium
@@ -274,7 +272,6 @@ todos:
     context: "In progress since yesterday. Need to update endpoint handlers and tests."
 
   - id: "019cdd2f-d4b3-7456-efab-567890abcdef"
-    position: 3
     action: prep
     title: "Renew gym membership"
     priority: low

--- a/config/claude/commands/today.md
+++ b/config/claude/commands/today.md
@@ -249,24 +249,38 @@ todos:
     title: "Fix tooltip alignment on dashboard widgets"
     priority: high  # enum: high, medium, low
     signal: sole_reviewer  # enum: sole_reviewer, author_replied, mentioned, direct_request, team_request, subscribed (omit for non-PR items)
-    source: todo_note  # enum: github, jira, slack, todo_note (omit or use most specific source when task comes from multiple)
-    category: personal  # enum: work, personal (omit for work — it's the default)
+    source: github  # enum: github, jira, slack, todo_note (omit or use most specific source when task comes from multiple)
+    # category omitted — defaults to work
     blocking: ["jdoe"]  # GitHub usernames of people waiting on me
     refs:
-      pr: "https://github.com/org/project/pull/1"
-      jira: "https://org.atlassian.net/browse/PROJECT-NNNN"  # if applicable
+      pr: "https://github.com/org/project/pull/123"
     refs_map:
-      "1": "https://github.com/org/project/pull/1"
-      "PROJECT-NNNN": "https://org.atlassian.net/browse/PROJECT-NNNN"
+      "123": "https://github.com/org/project/pull/123"
     usernames_map:
       "jdoe": "https://github.com/jdoe"
-    context: "Small bugfix (22+/1-), no reviews yet. jdoe is blocked."
+    context: "Small bugfix (22+/1-), no other reviewers. jdoe is blocked."
 
   - id: "019cdd2f-c8a2-7123-abcd-1234567890ab"
     position: 2
-    action: respond
-    signal: author_replied
-    # ... etc
+    action: write
+    title: "Finish API migration for PROJECT-1234"
+    priority: medium
+    source: todo_note
+    # category omitted — defaults to work
+    refs:
+      jira: "https://org.atlassian.net/browse/PROJECT-1234"
+    refs_map:
+      "PROJECT-1234": "https://org.atlassian.net/browse/PROJECT-1234"
+    context: "In progress since yesterday. Need to update endpoint handlers and tests."
+
+  - id: "019cdd2f-d4b3-7456-efab-567890abcdef"
+    position: 3
+    action: prep
+    title: "Renew gym membership"
+    priority: low
+    source: todo_note
+    category: personal  # enum: work, personal (omit for work — it's the default)
+    context: "Expires end of week."
 
 sources:
   todo_note:
@@ -290,7 +304,7 @@ sources:
   jira_tickets:
     - ref: "PROJECT-1234"
       url: "https://org.atlassian.net/browse/PROJECT-1234"
-      description: "Example ticket description"
+      description: "API migration for dashboard service"
     # ...
 ```
 

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -40,7 +40,7 @@ description: Brief description
 
 **Task Syntax** (in `*_todo.md` notes):
 - `[+]` - Completed
-- `[>]` - In progress
+- `[>]` - Moved to future date
 - `[ ]` - Pending
 - `[daily]` - Tag for daily recurring tasks
 


### PR DESCRIPTION
## Summary

Extend the `/today` command to automatically include manually-tracked tasks from the daily todo note alongside source-derived items (GitHub, Slack, Jira).

- Add Phase 0: create/read today's todo note via `notes` CLI, categorize tasks as work or personal, enrich work tasks with GitHub/Jira/note context
- Integrate todo note tasks into prioritization (work tasks at priority 8, personal at 11) with `source: todo_note` and `category: personal` labels
- Deduplicate overlapping items (e.g. todo note task referencing a PR also found in GitHub notifications) in Phase 2 before synthesis
- Add `TODO` badge for todo-note-only items, username mapping, `refs_map` for all linked references
- Fix notes SKILL.md: `[>]` means "moved to future date", not "in progress"
- Clean up: remove `#` prefix from PR numbers, drop hardcoded recurring tasks, remove redundant `position` field, remove `recurring` source enum

## Test plan

- [ ] Run `/today` with no args — verify todo note is created and tasks appear in output
- [ ] Run `/today` with a notes UID arg — verify context note informs prioritization
- [ ] Verify personal tasks appear at the bottom with `category: personal`
- [ ] Verify deduplication when a todo note task references a PR also found in notifications
- [ ] Verify YAML output at `$DAILIES_PATH/YYYYMMDD.yml` matches the documented structure