### PR TITLE
Simplify eod command prompt

### DIFF
--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -18,7 +18,7 @@ All subsequent steps use `$LOCAL_DATE` for display, and `$SEARCH_FROM` as the lo
 
 ## Phase 1: Gather Data (GitHub + Jira + Slack IN PARALLEL)
 
-**CRITICAL**: Phases 1a, 1b, and 1c are independent. Launch ALL THREE as parallel tool calls in a single message.
+**CRITICAL**: Phases 1a–1d are independent. Launch ALL FOUR as parallel tool calls in a single message.
 
 ### 1a: GitHub Activity (Bash)
 
@@ -73,6 +73,16 @@ Use `mcp__claude_ai_Slack__slack_search_public_and_private` to find significant 
 Run this search: `to:me during:$LOCAL_DATE`
 
 From the results, pick only items that are genuinely notable: incidents, architectural decisions, notable questions answered, or significant feedback. Skip routine noise and your own stand-alone EOD posts.
+
+### 1d: Personal Notes (Bash — run in parallel with 1a, 1b, 1c)
+
+List today's notes and read any that look relevant (e.g. todo, note, backlog):
+
+```
+notes ls --limit 10
+```
+
+Read notes from `$LOCAL_DATE` (filter by date prefix, e.g. `notes filter $LOCAL_DATE`). Include any tasks completed, personal observations, or context that would enrich the EOD report.
 
 ## Phase 2: Synthesize the Report
 

--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -93,6 +93,8 @@ Group by **activity or theme**, NOT by data source. Weave all sources into a nar
 **Example** (for structure/tone only):
 
 ```
+EOD Report:
+
 - Created ticket with a plan to evaluate vector search upgrade: [PROJ-123](...). I'd appreciate some [feedback](slack_permalink).
 - Reviewed [123](...) and [124](...) for Luis
 - Reviewed [125](...) for Becky
@@ -110,7 +112,7 @@ Group by **activity or theme**, NOT by data source. Weave all sources into a nar
 
 ## Phase 3: Save as Note
 
-Compose the note starting with `EOD report:` followed by the bullet list, then save:
+Save the report to the new note:
 
 ```
 echo "<note_content>" | notes new --slug eod --tag eod --tag reports

--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -6,45 +6,25 @@ Generate a daily EOD report and save it as a note.
 
 ## Phase 0: Resolve the Target Date
 
-If an argument was provided (e.g. "yesterday", "2d ago", "last Friday", a specific date), resolve it to a concrete calendar date in local timezone using Bash:
+If an argument was provided (e.g. "yesterday", "2d ago", "last Friday", a specific date), resolve it to a concrete calendar date in local timezone using `date`. If no argument was given, use today's local date.
 
-```bash
-# Examples — adapt based on the argument given:
-date -v-1d +%Y-%m-%d          # yesterday
-date -v-2d +%Y-%m-%d          # 2d ago
-date -v-friday +%Y-%m-%d      # last Friday (use -v-friday if already past it)
 ```
-
-If no argument was given, use today's local date:
-
-```bash
 LOCAL_DATE=$(date +%Y-%m-%d)
+# For API queries, search from one day before to avoid missing activity near day boundaries:
+SEARCH_FROM=$(date -v-1d -j -f "%Y-%m-%d" "$LOCAL_DATE" +%Y-%m-%d)
 ```
 
-Also compute the UTC equivalent date (for GitHub/Slack APIs which use UTC internally):
-
-```bash
-UTC_DATE=$(TZ=UTC date +%Y-%m-%d)
-# If LOCAL_DATE == UTC_DATE, use UTC_DATE for all searches.
-# If the local timezone is ahead of UTC (e.g. CET = UTC+1), activity at
-# the start of local day (e.g. 00:00–01:00 CET) falls on the previous UTC date.
-# Use LOCAL_DATE - 1 day as the lower bound for UTC-based searches to avoid
-# missing early-morning local-time activity:
-UTC_SEARCH_FROM=$(date -v-1d -j -f "%Y-%m-%d" "$LOCAL_DATE" +%Y-%m-%d 2>/dev/null \
-  || date -d "$LOCAL_DATE - 1 day" +%Y-%m-%d)
-```
-
-All subsequent steps use `$LOCAL_DATE` as the target date for display, and `$UTC_SEARCH_FROM` as the lower bound for API queries.
+All subsequent steps use `$LOCAL_DATE` for display, and `$SEARCH_FROM` as the lower bound for API queries.
 
 ## Phase 1: Gather Data (GitHub + Jira + Slack IN PARALLEL)
 
-**CRITICAL**: Phases 1a, 1b, and 1c are independent. Launch ALL THREE as parallel tool calls in a single message. Do NOT run them sequentially.
+**CRITICAL**: Phases 1a, 1b, and 1c are independent. Launch ALL THREE as parallel tool calls in a single message.
 
 ### 1a: GitHub Activity (Bash)
 
-```bash
+```
 LOCAL_DATE=<resolved above>
-UTC_SEARCH_FROM=<resolved above>
+SEARCH_FROM=<resolved above>
 
 echo "=== MY PRs ==="
 gh pr list --author @me --state all --limit 30 \
@@ -52,73 +32,45 @@ gh pr list --author @me --state all --limit 30 \
   | python3 -c "
 import sys, json
 target = '$LOCAL_DATE'
+search_from = '$SEARCH_FROM'
 prs = json.load(sys.stdin)
 for p in prs:
     updated = p['updatedAt'][:10]
     merged  = (p.get('mergedAt') or '')[:10]
-    if updated == target or merged == target:
+    if updated >= search_from and (updated <= target or merged <= target):
         print(p['state'], p['number'], p['title'], p['url'])
 "
 
 echo "=== REVIEWED ==="
-gh search prs --reviewed-by @me --updated ">=$UTC_SEARCH_FROM" --limit 20 \
+gh search prs --reviewed-by @me --updated ">=$SEARCH_FROM" --limit 20 \
   --json number,title,url,updatedAt \
   | python3 -c "
-import sys, json, subprocess
-from datetime import datetime, timedelta
-target = '\$LOCAL_DATE'
-# GitHub timestamps are UTC; convert to local date using system TZ offset before filtering.
-try:
-    tz_offset_h = int(subprocess.check_output(['date', '+%z']).decode().strip()) // 100
-except Exception:
-    tz_offset_h = 0
-offset = timedelta(hours=tz_offset_h)
+import sys, json
+search_from = '$SEARCH_FROM'
+target = '$LOCAL_DATE'
 prs = json.load(sys.stdin)
 for p in prs:
-    dt_utc = datetime.fromisoformat(p['updatedAt'].replace('Z', '+00:00')).replace(tzinfo=None)
-    local_date = (dt_utc + offset).strftime('%Y-%m-%d')
-    if local_date == target:
+    d = p['updatedAt'][:10]
+    if search_from <= d <= target:
         print(p['number'], p['title'], p['url'])
 "
-
-echo "=== NOTIFICATIONS ==="
-gh api "/notifications?all=true&since=${UTC_SEARCH_FROM}T00:00:00Z" --paginate \
-  | python3 -c "
-import sys, json
-ns = json.load(sys.stdin)
-for n in ns:
-    if n.get('reason') in ('review_requested', 'mention', 'comment'):
-        print(n['reason'], n['subject']['title'], n['subject']['url'])
-" 2>/dev/null || true
 ```
 
 ### 1b: Jira Activity (Bash — run in parallel with 1a and 1c)
 
-```bash
+```
 acli jira --action getIssueList \
-  --jql "assignee = currentUser() AND status in ('In Progress', 'In Review') ORDER BY updated DESC" \
-  --columns "key,summary,status" --limit 10 2>/dev/null || true
-
-echo "---RECENT---"
-
-acli jira --action getIssueList \
-  --jql "assignee = currentUser() AND updated >= startOfDay() ORDER BY updated DESC" \
-  --columns "key,summary,status" --limit 10 2>/dev/null || true
+  --jql "assignee = currentUser() AND (status in ('In Progress', 'In Review') OR updated >= startOfDay()) ORDER BY updated DESC" \
+  --columns "key,summary,status" --limit 15 2>/dev/null || true
 ```
 
 ### 1c: Slack Activity (run in parallel with 1a and 1b)
 
 Use `mcp__claude_ai_Slack__slack_search_public_and_private` to find significant discussions from `$LOCAL_DATE`.
 
-**Important**: Do NOT search for `from:me` — that returns your own EOD posts and messages, which are output, not input. Instead, search for discussions and decisions you were involved in or that were significant.
+**Important**: Do NOT search for `from:me` — that returns your own EOD posts, which are output, not input.
 
-Run these searches (use `after:YYYY-MM-DD` with `$UTC_SEARCH_FROM`). Launch both Slack searches as parallel tool calls:
-
-1. Threads you were mentioned in or replied to: `to:me after:$UTC_SEARCH_FROM` and `to:me during:$LOCAL_DATE`
-
-2. Significant engineering discussions in key channels (decisions, incidents, architectural choices): `in:#eng after:$UTC_SEARCH_FROM has:reaction` or similar high-signal queries
-
-3. If the date is not today, also try: `after:$UTC_SEARCH_FROM before:$LOCAL_DATE_PLUS_1`
+Run this search: `to:me during:$LOCAL_DATE`
 
 From the results, pick only items that are genuinely notable: incidents, architectural decisions, notable questions answered, or significant feedback. Skip routine noise and your own stand-alone EOD posts.
 
@@ -126,9 +78,9 @@ From the results, pick only items that are genuinely notable: incidents, archite
 
 Produce a concise bullet-point EOD report for **$LOCAL_DATE**.
 
-**Organizational principle**: Group by **activity or theme**, NOT by data source. Do not create separate GitHub/Jira/Slack sections. Instead, weave all sources into a narrative where each bullet describes what you did and why. A single bullet may reference a Jira ticket, a PR, and a Slack thread together if they're part of the same activity.
+Group by **activity or theme**, NOT by data source. Weave all sources into a narrative where each bullet describes what you did and why. A single bullet may reference a Jira ticket, a PR, and a Slack thread together if they're part of the same activity.
 
-**Example** (for structure/tone only — actual content will differ):
+**Example** (for structure/tone only):
 
 ```
 - Created ticket with a plan to evaluate vector search upgrade: [PROJ-123](...). I'd appreciate some [feedback](slack_permalink).
@@ -142,19 +94,13 @@ Produce a concise bullet-point EOD report for **$LOCAL_DATE**.
 - Cycle checkin
 ```
 
-**Linking rules**:
-- PRs: `[504](pr_url)` — number only, no title
-- Jira: `[PROJ-123](ticket_url)`
-- Slack/video/external links: descriptive anchor text, e.g. `[feedback](slack_permalink)`, `[New tool intro](video_link)`
-
-**Style rules**:
-- First person, concise but informative — each bullet tells what was done and gives context
-- Use sub-bullets (4-space indent) to group related items under a theme (e.g. epic review, multi-ticket investigation)
+**Style**:
+- First person, concise but informative
+- Links: PRs as `[504](url)`, Jira as `[PROJ-123](url)`, everything else with descriptive anchor text
+- Use sub-bullets (4-space indent) to group related items under a theme
 - Code reviews go on one line: `Code reviews: [504](...), [503](...)`
-- Include non-code activities: meetings, checkins, videos watched, ticket/plan creation, discussions
-- Embed links contextually within the narrative — don't isolate Slack/Jira/PR links into their own sections
-- Include personal notes or requests when relevant (e.g. "needs review", "I'd appreciate feedback")
-- Omit routine noise — only include items that are genuinely worth reporting
+- Include non-code activities: meetings, checkins, videos, discussions
+- Omit routine noise
 
 ## Phase 3: Save as Note
 
@@ -163,7 +109,7 @@ Produce a concise bullet-point EOD report for **$LOCAL_DATE**.
 ```yaml
 ---
 slug: eod
-tags: [eod, zipline, reports]
+tags: [eod, reports]
 ---
 ```
 
@@ -171,7 +117,7 @@ Followed by `EOD report:` and the bullet list.
 
 2. Save it:
 
-```bash
+```
 printf '%s' "<note_content>" | notes new --slug eod
 ```
 

--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -104,21 +104,10 @@ Group by **activity or theme**, NOT by data source. Weave all sources into a nar
 
 ## Phase 3: Save as Note
 
-1. Compose the note with this YAML frontmatter:
-
-```yaml
----
-slug: eod
-tags: [eod, reports]
----
-```
-
-Followed by `EOD report:` and the bullet list.
-
-2. Save it:
+Compose the note starting with `EOD report:` followed by the bullet list, then save:
 
 ```
-printf '%s' "<note_content>" | notes new --slug eod
+echo "<note_content>" | notes new --slug eod --tag eod --tag reports
 ```
 
-3. Report the saved file path.
+Report the saved file path.

--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -84,23 +84,19 @@ Group by **activity or theme**, NOT by data source. Weave all sources into a nar
 
 ```
 - Created ticket with a plan to evaluate vector search upgrade: [PROJ-123](...). I'd appreciate some [feedback](slack_permalink).
-- Epic review:
-    - [PROJ-101](...) — corrected AC, scoped to UI only, closed (after [501](...) merge).
-    - [PROJ-102](...) — created new ticket for backend wiring (depends on [498](...)).
-    - [PROJ-103](...) — drafted status update comment.
-- Code reviews: [504](...), [503](...), [499](...)
+- Reviewed [123](...) and [124](...) for Luis
+- Reviewed [125](...) for Becky
 - Watched [New tool intro](video_link)
-- Batching spike is open and needs review: [PROJ-200](...).
+- Batching spike is open and needs review: [PROJ-1000](...).
 - Cycle checkin
 ```
 
 **Style**:
 - First person, concise but informative
-- Links: PRs as `[504](url)`, Jira as `[PROJ-123](url)`, everything else with descriptive anchor text
-- Use sub-bullets (4-space indent) to group related items under a theme
-- Code reviews go on one line: `Code reviews: [504](...), [503](...)`
-- Include non-code activities: meetings, checkins, videos, discussions
-- Omit routine noise
+- Links: PRs as `[123](url)`, Jira as `[PROJ-123](url)`, everything else with descriptive anchor text
+- Prefer flat lists with no nesting. But use sub-bullets (4-space indent) if it makes sense to group related items under a theme.
+- Include non-code activities: meetings, checkins, discussions
+- Omit low-value items and routine noise
 
 ## Phase 3: Save as Note
 

--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -56,7 +56,7 @@ for p in prs:
 "
 ```
 
-### 1b: Jira Activity (Bash — run in parallel with 1a and 1c)
+### 1b: Jira Activity (Bash)
 
 ```
 acli jira --action getIssueList \
@@ -64,7 +64,7 @@ acli jira --action getIssueList \
   --columns "key,summary,status" --limit 15 2>/dev/null || true
 ```
 
-### 1c: Slack Activity (run in parallel with 1a and 1b)
+### 1c: Slack Activity
 
 Use `mcp__claude_ai_Slack__slack_search_public_and_private` to find significant discussions from `$LOCAL_DATE`.
 
@@ -74,7 +74,7 @@ Run this search: `to:me during:$LOCAL_DATE`
 
 From the results, pick only items that are genuinely notable: incidents, architectural decisions, notable questions answered, or significant feedback. Skip routine noise and your own stand-alone EOD posts.
 
-### 1d: Personal Notes (Bash — run in parallel with 1a, 1b, 1c)
+### 1d: Personal Notes (Bash)
 
 List today's notes and read any that look relevant (e.g. todo, note, backlog):
 


### PR DESCRIPTION
Remove redundant timezone handling and overlapping queries. Merge duplicate Jira queries, drop low-signal GitHub notifications, consolidate Slack searches. Use notes CLI flags instead of YAML frontmatter for slug/tags. ~65 lines removed with no signal loss.