### PR TITLE
Fix eod prompt: accurate review dates, parameterized queries

### DIFF
--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -49,17 +49,40 @@ for p in prs:
 "
 
 echo "=== REVIEWED ==="
-gh search prs --reviewed-by @me --updated ">=$SEARCH_FROM" --limit 20 \
-  --json number,title,url,updatedAt \
-  | python3 -c "
-import sys, json
+# Use the events API to get actual review submission timestamps (not PR update dates).
+# Paginate up to 3 pages to cover ~1 week of activity.
+python3 -c "
+import subprocess, json
 search_from = '$SEARCH_FROM'
 target = '$LOCAL_DATE'
-prs = json.load(sys.stdin)
-for p in prs:
-    d = p['updatedAt'][:10]
-    if search_from <= d <= target:
-        print(p['number'], p['title'], p['url'])
+seen = set()
+matches = []
+for page in range(1, 4):
+    result = subprocess.run(
+        ['gh', 'api', f'/users/dreikanter/events?per_page=100&page={page}'],
+        capture_output=True, text=True)
+    if result.returncode != 0: break
+    for e in json.loads(result.stdout):
+        if e['type'] != 'PullRequestReviewEvent': continue
+        reviewed = e['created_at'][:10]
+        if reviewed < search_from: break
+        if reviewed > target: continue
+        repo = e['repo']['name']
+        num = e['payload']['pull_request']['number']
+        key = (repo, num)
+        if key in seen: continue
+        seen.add(key)
+        matches.append((repo, num))
+    else: continue
+    break
+# Fetch titles for matched PRs
+for repo, num in matches:
+    result = subprocess.run(
+        ['gh', 'api', f'/repos/{repo}/pulls/{num}', '--jq', '.title'],
+        capture_output=True, text=True)
+    title = result.stdout.strip() if result.returncode == 0 else '(unknown)'
+    url = f'https://github.com/{repo}/pull/{num}'
+    print(num, title, url)
 "
 ```
 

--- a/config/claude/commands/eod.md
+++ b/config/claude/commands/eod.md
@@ -9,14 +9,21 @@ Generate a daily EOD report and save it as a note.
 If an argument was provided (e.g. "yesterday", "2d ago", "last Friday", a specific date), resolve it to a concrete calendar date in local timezone using `date`. If no argument was given, use today's local date.
 
 ```
-LOCAL_DATE=$(date +%Y-%m-%d)
+# No argument → today; with argument → resolve it, e.g.:
+#   "yesterday"        → date -v-1d +%Y-%m-%d
+#   "2d ago"           → date -v-2d +%Y-%m-%d
+#   "last Friday"      → date -v-Fri +%Y-%m-%d
+#   "2026-03-05"       → echo "2026-03-05"
+LOCAL_DATE=<resolved date in %Y-%m-%d format>
 # For API queries, search from one day before to avoid missing activity near day boundaries:
 SEARCH_FROM=$(date -v-1d -j -f "%Y-%m-%d" "$LOCAL_DATE" +%Y-%m-%d)
+# Day after LOCAL_DATE (used for Slack date-range queries):
+SEARCH_UNTIL=$(date -v+1d -j -f "%Y-%m-%d" "$LOCAL_DATE" +%Y-%m-%d)
 ```
 
 All subsequent steps use `$LOCAL_DATE` for display, and `$SEARCH_FROM` as the lower bound for API queries.
 
-## Phase 1: Gather Data (GitHub + Jira + Slack IN PARALLEL)
+## Phase 1: Gather Data (GitHub + Jira + Slack + Notes IN PARALLEL)
 
 **CRITICAL**: Phases 1a–1d are independent. Launch ALL FOUR as parallel tool calls in a single message.
 
@@ -60,7 +67,7 @@ for p in prs:
 
 ```
 acli jira --action getIssueList \
-  --jql "assignee = currentUser() AND (status in ('In Progress', 'In Review') OR updated >= startOfDay()) ORDER BY updated DESC" \
+  --jql "assignee = currentUser() AND (status in ('In Progress', 'In Review') OR updated >= '$LOCAL_DATE') ORDER BY updated DESC" \
   --columns "key,summary,status" --limit 15 2>/dev/null || true
 ```
 
@@ -70,23 +77,25 @@ Use `mcp__claude_ai_Slack__slack_search_public_and_private` to find significant 
 
 **Important**: Do NOT search for `from:me` — that returns your own EOD posts, which are output, not input.
 
-Run this search: `to:me during:$LOCAL_DATE`
+Run this search: `to:me after:$SEARCH_FROM before:$SEARCH_UNTIL`
 
 From the results, pick only items that are genuinely notable: incidents, architectural decisions, notable questions answered, or significant feedback. Skip routine noise and your own stand-alone EOD posts.
 
 ### 1d: Personal Notes (Bash)
 
-List today's notes and read any that look relevant (e.g. todo, note, backlog):
+List notes from the target date and read any that look relevant (e.g. todo, note, backlog):
 
 ```
-notes ls --limit 10
+notes filter $LOCAL_DATE
 ```
 
-Read notes from `$LOCAL_DATE` (filter by date prefix, e.g. `notes filter $LOCAL_DATE`). Include any tasks completed, personal observations, or context that would enrich the EOD report.
+Read matching notes. Include any tasks completed, personal observations, or context that would enrich the EOD report.
 
 ## Phase 2: Synthesize the Report
 
 Produce a concise bullet-point EOD report for **$LOCAL_DATE**.
+
+**Deduplicate across sources before writing.** A PR you authored may also appear in reviewed PRs or Slack threads — mention it once, in the most meaningful context.
 
 Group by **activity or theme**, NOT by data source. Weave all sources into a narrative where each bullet describes what you did and why. A single bullet may reference a Jira ticket, a PR, and a Slack thread together if they're part of the same activity.
 
@@ -100,6 +109,7 @@ EOD Report:
 - Reviewed [125](...) for Becky
 - Watched [New tool intro](video_link)
 - Batching spike is open and needs review: [PROJ-1000](...).
+- Updated backlog note with Q2 capacity estimates
 - Cycle checkin
 ```
 
@@ -115,7 +125,9 @@ EOD Report:
 Save the report to the new note:
 
 ```
-echo "<note_content>" | notes new --slug eod --tag eod --tag reports
+cat <<'EOF' | notes new --slug eod --tag eod --tag reports
+<note_content>
+EOF
 ```
 
 Report the saved file path.


### PR DESCRIPTION
## Summary

- **Reviewed PRs**: Switch from `gh search prs --updated` (filters by PR update date) to GitHub events API which provides actual review submission timestamps. Validated with real data.
- **Date handling**: Add examples for resolving date arguments (yesterday, 2d ago, etc.), add `SEARCH_UNTIL` for upper-bound queries.
- **Jira**: Replace `startOfDay()` with `$LOCAL_DATE` so past-date queries work.
- **Slack**: Replace `during:` (doesn't accept YYYY-MM-DD) with `after:/before:` date range.
- **Notes**: Use `notes filter $LOCAL_DATE` directly instead of `notes ls --limit 10`.
- **Minor**: Add dedup guidance, note-sourced example bullet, safe heredoc for save, fix phase heading.

## Test plan

- [x] Validated events API returns correct review dates for today and past dates
- [x] Confirmed `gh search prs --updated` was returning false positives (PRs updated today but reviewed weeks ago)