### PR TITLE
Replace notes helper scripts with notes CLI wrappers

### DIFF
--- a/bin/latest-backlog
+++ b/bin/latest-backlog
@@ -1,13 +1,14 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-NOTES_PATH = ENV["NOTES_PATH"] || File.expand_path("~/Dropbox/Notes")
-VISUAL_EDITOR = ENV["NOTES_EDITOR"] || "/opt/homebrew/bin/subl --add"
+set -euo pipefail
 
-wildcard = File.join(NOTES_PATH, "**", "*_backlog.md")
-last_note_path = Dir.glob(wildcard).grep(%r{\d+/\d{2}/.*\.md}).max
-begin
-  pid = Process.spawn("#{VISUAL_EDITOR} #{NOTES_PATH} #{last_note_path}")
-  Process.detach(pid)
-rescue StandardError => e
-  warn "Failed to launch editor (#{VISUAL_EDITOR}): #{e.message}"
-end
+if ! command -v notes &>/dev/null; then
+  echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
+  exit 1
+fi
+
+NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
+file_path="$NOTES_PATH/$(notes ls --type backlog --limit 1)"
+
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "$NOTES_PATH" "$file_path" &
+disown

--- a/bin/latest-note
+++ b/bin/latest-note
@@ -1,18 +1,14 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-NOTES_PATH = ENV["NOTES_PATH"] || File.expand_path("~/Dropbox/Notes")
-VISUAL_EDITOR = ENV["NOTES_EDITOR"] || "/opt/homebrew/bin/subl --add"
+set -euo pipefail
 
-# Skip "99999999_*" notes
-def pinned?(path)
-  File.basename(path) =~ /^9+_/
-end
+if ! command -v notes &>/dev/null; then
+  echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
+  exit 1
+fi
 
-wildcard = File.join(NOTES_PATH, "**", "*.md")
-last_note_path = Dir.glob(wildcard).grep(%r{\d+/\d{2}/.*\.md}).reject { |path| pinned?(path) }.max
-begin
-  pid = Process.spawn("#{VISUAL_EDITOR} #{NOTES_PATH} #{last_note_path}")
-  Process.detach(pid)
-rescue StandardError => e
-  warn "Failed to launch editor (#{VISUAL_EDITOR}): #{e.message}"
-end
+NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
+file_path="$NOTES_PATH/$(notes ls --limit 1)"
+
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "$NOTES_PATH" "$file_path" &
+disown

--- a/bin/latest-todo
+++ b/bin/latest-todo
@@ -1,18 +1,14 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-NOTES_PATH = ENV["NOTES_PATH"] || File.expand_path("~/Dropbox/Notes")
-VISUAL_EDITOR = ENV["NOTES_EDITOR"] || "/opt/homebrew/bin/subl --add"
+set -euo pipefail
 
-# Skip "99999999_*" notes
-def pinned?(path)
-  File.basename(path) =~ /^9+_/
-end
+if ! command -v notes &>/dev/null; then
+  echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
+  exit 1
+fi
 
-wildcard = File.join(NOTES_PATH, "**", "*_todo.md")
-last_note_path = Dir.glob(wildcard).grep(%r{\d+/\d{2}/.*\.md}).reject { |path| pinned?(path) }.max
-begin
-  pid = Process.spawn("#{VISUAL_EDITOR} #{NOTES_PATH} #{last_note_path}")
-  Process.detach(pid)
-rescue StandardError => e
-  warn "Failed to launch editor (#{VISUAL_EDITOR}): #{e.message}"
-end
+NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
+file_path="$NOTES_PATH/$(notes ls --type todo --limit 1)"
+
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "$NOTES_PATH" "$file_path" &
+disown

--- a/bin/latest-weekly
+++ b/bin/latest-weekly
@@ -1,13 +1,14 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-NOTES_PATH = ENV["NOTES_PATH"] || File.expand_path("~/Dropbox/Notes")
-VISUAL_EDITOR = ENV["NOTES_EDITOR"] || "/opt/homebrew/bin/subl --add"
+set -euo pipefail
 
-# Skip "99999999_*" notes
-def pinned?(path)
-  File.basename(path) =~ /^9+_/
-end
+if ! command -v notes &>/dev/null; then
+  echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
+  exit 1
+fi
 
-wildcard = File.join(NOTES_PATH, "**", "*_weekly.md")
-last_note_path = Dir.glob(wildcard).grep(%r{\d+/\d{2}/.*\.md}).reject { |path| pinned?(path) }.max
-system("#{VISUAL_EDITOR} #{NOTES_PATH} #{last_note_path}")
+NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
+file_path="$NOTES_PATH/$(notes ls --type weekly --limit 1)"
+
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "$NOTES_PATH" "$file_path" &
+disown

--- a/bin/new-note
+++ b/bin/new-note
@@ -1,91 +1,69 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-require "fileutils"
-require "json"
-require "optparse"
+set -euo pipefail
 
-NOTES_PATH = ENV["NOTES_PATH"] || File.expand_path("~/Dropbox/Notes")
-VISUAL_EDITOR = ENV["NOTES_EDITOR"] || "/opt/homebrew/bin/subl --add"
+VISUAL_EDITOR="${NOTES_EDITOR:-/opt/homebrew/bin/subl --add}"
+NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
 
-ID_PATH = File.join(NOTES_PATH, "id.json")
+if ! command -v notes &>/dev/null; then
+  echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
+  echo "See: https://github.com/dreikanter/notes" >&2
+  exit 1
+fi
 
-options = { tags: [] }
+tags=()
+slug=""
+location=""
 
-parser = OptionParser.new do |opts|
-  opts.banner = "Usage: new-note [options]"
-  opts.separator ""
-  opts.separator "Creates a new note with auto-incremented ID and opens it in the editor."
-  opts.separator ""
-  opts.separator "Options:"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag=*) tags+=("${1#--tag=}"); shift ;;
+    --tag) tags+=("$2"); shift 2 ;;
+    --slug=*) slug="${1#--slug=}"; shift ;;
+    --slug) slug="$2"; shift 2 ;;
+    --location=*) location="${1#--location=}"; shift ;;
+    --location) location="$2"; shift 2 ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: new-note [options]
 
-  opts.on("--tag=TAG", "Add a tag (can be used multiple times)") do |tag|
-    options[:tags] << tag
-  end
+Creates a new note with auto-incremented ID and opens it in the editor.
 
-  opts.on("--location=LOCATION", "Set location in frontmatter") do |loc|
-    options[:location] = loc
-  end
+Options:
+  --tag=TAG          Add a tag (can be used multiple times)
+  --location=LOC     Set location in frontmatter
+  --slug=SLUG        Add slug suffix to filename
+  -h, --help         Show this help message
 
-  opts.on("--slug=SLUG", "Add slug suffix to filename") do |slug|
-    options[:slug] = slug
-  end
+Examples:
+  new-note
+  new-note --tag=journal --location="Berlin, Germany" --slug=journal
+  new-note --tag=idea --tag=project
 
-  opts.on("-h", "--help", "Show this help message") do
-    puts opts
-    puts ""
-    puts "Examples:"
-    puts "  new-note"
-    puts "  new-note --tag=journal --location=\"Berlin, Germany\" --slug=journal"
-    puts "  new-note --tag=idea --tag=project"
-    puts ""
-    puts "Environment variables:"
-    puts "  NOTES_PATH    Notes directory (default: ~/Dropbox/Notes)"
-    puts "  NOTES_EDITOR  Editor command (default: /opt/homebrew/bin/subl --add)"
-    exit
-  end
-end
+Environment variables:
+  NOTES_PATH    Notes directory (default: ~/Dropbox/Notes)
+  NOTES_EDITOR  Editor command (default: /opt/homebrew/bin/subl --add)
+EOF
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
 
-parser.parse!
+args=()
+for tag in "${tags[@]}"; do
+  args+=(--tag "$tag")
+done
+[[ -n "$slug" ]] && args+=(--slug "$slug")
 
-def new_note_path(time, slug: nil)
-  suffix = slug ? "_#{slug}" : ""
-  File.join(
-    File.join(NOTES_PATH, time.strftime("%Y"), time.strftime("%m")),
-    "#{time.strftime("%Y%m%d")}_#{generate_new_id}#{suffix}.md"
-  )
-end
+if [[ -n "$location" ]]; then
+  # notes CLI doesn't support --location; inject it via stdin frontmatter
+  file_path=$(printf -- '---\nlocation: %s\n---\n' "$location" | notes new "${args[@]}")
+else
+  file_path=$(notes new "${args[@]}")
+fi
 
-def generate_new_id
-  new_id = last_id.succ
-  File.write(ID_PATH, JSON.generate({ last_id: new_id }))
-  new_id
-end
+echo "$file_path"
 
-def last_id
-  Integer(JSON.parse(File.read(ID_PATH))["last_id"])
-rescue StandardError
-  Dir.glob(File.join(NOTES_PATH, "**/*.md")).count
-end
-
-def generate_frontmatter(options)
-  lines = []
-  lines << "tags: [#{options[:tags].join(", ")}]" unless options[:tags].empty?
-  lines << "location: #{options[:location]}" if options[:location]
-  return "" if lines.empty?
-
-  "---\n#{lines.join("\n")}\n---\n\n"
-end
-
-file_name = new_note_path(Time.now, slug: options[:slug])
-puts file_name
-FileUtils.mkdir_p(File.dirname(file_name))
-
-frontmatter = generate_frontmatter(options)
-File.write(file_name, frontmatter) unless frontmatter.empty?
-
-begin
-  pid = Process.spawn("#{VISUAL_EDITOR} #{NOTES_PATH} #{file_name}")
-  Process.detach(pid)
-rescue StandardError => e
-  warn "Failed to launch editor (#{VISUAL_EDITOR}): #{e.message}"
-end
+$VISUAL_EDITOR "$NOTES_PATH" "$file_path" &
+disown

--- a/bin/new-note
+++ b/bin/new-note
@@ -2,68 +2,13 @@
 
 set -euo pipefail
 
-VISUAL_EDITOR="${NOTES_EDITOR:-/opt/homebrew/bin/subl --add}"
-NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
-
 if ! command -v notes &>/dev/null; then
   echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
-  echo "See: https://github.com/dreikanter/notes" >&2
   exit 1
 fi
 
-tags=()
-slug=""
-location=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --tag=*) tags+=("${1#--tag=}"); shift ;;
-    --tag) tags+=("$2"); shift 2 ;;
-    --slug=*) slug="${1#--slug=}"; shift ;;
-    --slug) slug="$2"; shift 2 ;;
-    --location=*) location="${1#--location=}"; shift ;;
-    --location) location="$2"; shift 2 ;;
-    -h|--help)
-      cat <<'EOF'
-Usage: new-note [options]
-
-Creates a new note with auto-incremented ID and opens it in the editor.
-
-Options:
-  --tag=TAG          Add a tag (can be used multiple times)
-  --location=LOC     Set location in frontmatter
-  --slug=SLUG        Add slug suffix to filename
-  -h, --help         Show this help message
-
-Examples:
-  new-note
-  new-note --tag=journal --location="Berlin, Germany" --slug=journal
-  new-note --tag=idea --tag=project
-
-Environment variables:
-  NOTES_PATH    Notes directory (default: ~/Dropbox/Notes)
-  NOTES_EDITOR  Editor command (default: /opt/homebrew/bin/subl --add)
-EOF
-      exit 0
-      ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
-  esac
-done
-
-args=()
-for tag in "${tags[@]}"; do
-  args+=(--tag "$tag")
-done
-[[ -n "$slug" ]] && args+=(--slug "$slug")
-
-if [[ -n "$location" ]]; then
-  # notes CLI doesn't support --location; inject it via stdin frontmatter
-  file_path=$(printf -- '---\nlocation: %s\n---\n' "$location" | notes new "${args[@]}")
-else
-  file_path=$(notes new "${args[@]}")
-fi
-
+file_path=$(notes new "$@")
 echo "$file_path"
 
-$VISUAL_EDITOR "$NOTES_PATH" "$file_path" &
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "${NOTES_PATH:-$HOME/Dropbox/Notes}" "$file_path" &
 disown

--- a/bin/new-note
+++ b/bin/new-note
@@ -7,7 +7,7 @@ if ! command -v notes &>/dev/null; then
   exit 1
 fi
 
-file_path=$(notes new "$@")
+file_path=$(notes new)
 echo "$file_path"
 
 ${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "${NOTES_PATH:-$HOME/Dropbox/Notes}" "$file_path" &

--- a/bin/new-todo
+++ b/bin/new-todo
@@ -1,187 +1,30 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-require "date"
-require "fileutils"
-require "json"
-require "optparse"
+set -euo pipefail
 
-NOTES_PATH = ENV["NOTES_PATH"] || File.expand_path("~/Dropbox/Notes")
-VISUAL_EDITOR = ENV["NOTES_EDITOR"] || "/opt/homebrew/bin/subl --add"
-ID_PATH = File.join(NOTES_PATH, "id.json")
+VISUAL_EDITOR="${NOTES_EDITOR:-/opt/homebrew/bin/subl --add}"
+NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
 
-TASK_REGEX = /^(?<indent>\s*)(?<bullet>- )?\[(?<marker>.?)\](?<body>.*)$/
-
-def pinned?(path)
-  File.basename(path) =~ /^9+_/
-end
-
-def todo_date_from(path)
-  if (match = File.basename(path).match(/^(\d{8})_\d+_todo\.md$/))
-    Date.strptime(match[1], "%Y%m%d")
-  end
-rescue ArgumentError
-  nil
-end
-
-def find_today_todo_path(date)
-  pattern = File.join(
-    NOTES_PATH,
-    date.strftime("%Y"),
-    date.strftime("%m"),
-    "#{date.strftime("%Y%m%d")}_*_todo.md"
-  )
-
-  Dir.glob(pattern).reject { |path| pinned?(path) }.max
-end
-
-def find_previous_todo(date)
-  pattern = File.join(NOTES_PATH, "*", "*", "*_todo.md")
-  best = nil
-
-  Dir.glob(pattern).reject { |path| pinned?(path) }.each do |path|
-    todo_date = todo_date_from(path)
-    next unless todo_date && todo_date < date
-
-    if best.nil? || todo_date > best.first || (todo_date == best.first && path > best.last)
-      best = [todo_date, path]
-    end
-  end
-
-  best
-end
-
-def last_id
-  Integer(JSON.parse(File.read(ID_PATH))["last_id"])
-rescue StandardError
-  Dir.glob(File.join(NOTES_PATH, "**/*.md")).count
-end
-
-def generate_new_id
-  new_id = last_id.succ
-  File.write(ID_PATH, JSON.generate({ last_id: new_id }))
-  new_id
-end
-
-def build_todo_path(date, id)
-  File.join(
-    File.join(NOTES_PATH, date.strftime("%Y"), date.strftime("%m")),
-    "#{date.strftime("%Y%m%d")}_#{id}_todo.md"
-  )
-end
-
-def split_line_and_newline(line)
-  if line.end_with?("\r\n")
-    [line[0...-2], "\r\n"]
-  elsif line.end_with?("\n")
-    [line[0...-1], "\n"]
-  else
-    [line, ""]
-  end
-end
-
-def extract_tasks(path, include_moved:)
-  lines = File.readlines(path, chomp: false)
-  daily_tasks = []
-  regular_tasks = []
-  updated_lines = []
-  modified = false
-
-  lines.each_with_index do |line, index|
-    content, newline = split_line_and_newline(line)
-    match = content.match(TASK_REGEX)
-
-    unless match
-      updated_lines << line
-      next
-    end
-
-    indent = match[:indent]
-    bullet = match[:bullet] || ""
-    marker = match[:marker]
-    body = match[:body]
-    task_text = "#{indent}- [ ]#{body}"
-    daily = body.include?("[daily]")
-
-    case marker
-    when " "
-      regular_tasks << [index, task_text]
-      updated_lines << "#{indent}#{bullet}[>]#{body}#{newline}"
-      modified = true
-    when ">"
-      regular_tasks << [index, task_text] if include_moved
-      updated_lines << "#{indent}#{bullet}[>]#{body}#{newline}"
-    else
-      updated_lines << line
-    end
-
-    daily_tasks << [index, task_text] if daily
-  end
-
-  daily_tasks.sort_by!(&:first)
-  regular_tasks.sort_by!(&:first)
-
-  combined_tasks = []
-  (daily_tasks + regular_tasks).each do |(_, task)|
-    combined_tasks << task unless combined_tasks.include?(task)
-  end
-
-  [combined_tasks, modified ? updated_lines.join : nil]
-end
-
-def build_todo_content(tasks)
-  body = tasks.join("\n\n")
-  content = +"---\nslug: todo\n---\n\n"
-  content << body unless body.empty?
-  content << "\n" unless content.end_with?("\n")
-  content
-end
-
-options = { force: false }
-
-OptionParser.new do |opts|
-  opts.on("--force", "Regenerate today's todo note") { options[:force] = true }
-end.parse!(ARGV)
-
-today = Date.today
-existing_today_path = find_today_todo_path(today)
-
-if existing_today_path && !options[:force]
-  puts existing_today_path
-  exit 0
-end
-
-previous_todo = find_previous_todo(today)
-
-unless previous_todo
-  warn "No previous todo note found."
+if ! command -v notes &>/dev/null; then
+  echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
+  echo "See: https://github.com/dreikanter/notes" >&2
   exit 1
-end
+fi
 
-previous_date, previous_path = previous_todo
-tasks_to_copy, updated_previous_content = extract_tasks(previous_path, include_moved: options[:force])
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    --force) args+=(--force) ;;
+    -h|--help)
+      notes new-todo --help
+      exit 0
+      ;;
+    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
 
-if tasks_to_copy.empty?
-  warn "No tasks to carry over from #{previous_path}."
-end
+file_path=$(notes new-todo "${args[@]}")
+echo "$file_path"
 
-today_path = existing_today_path
-
-unless today_path
-  new_id = generate_new_id
-  today_path = build_todo_path(today, new_id)
-end
-
-FileUtils.mkdir_p(File.dirname(today_path))
-File.write(today_path, build_todo_content(tasks_to_copy))
-
-if updated_previous_content
-  File.write(previous_path, updated_previous_content)
-end
-
-puts today_path
-begin
-  pid = Process.spawn("#{VISUAL_EDITOR} #{NOTES_PATH} #{today_path}")
-  Process.detach(pid)
-rescue StandardError => e
-  warn "Failed to launch editor (#{VISUAL_EDITOR}): #{e.message}"
-end
+$VISUAL_EDITOR "$NOTES_PATH" "$file_path" &
+disown

--- a/bin/new-todo
+++ b/bin/new-todo
@@ -2,29 +2,13 @@
 
 set -euo pipefail
 
-VISUAL_EDITOR="${NOTES_EDITOR:-/opt/homebrew/bin/subl --add}"
-NOTES_PATH="${NOTES_PATH:-$HOME/Dropbox/Notes}"
-
 if ! command -v notes &>/dev/null; then
   echo "Error: 'notes' CLI not found in PATH. Install it first." >&2
-  echo "See: https://github.com/dreikanter/notes" >&2
   exit 1
 fi
 
-args=()
-for arg in "$@"; do
-  case "$arg" in
-    --force) args+=(--force) ;;
-    -h|--help)
-      notes new-todo --help
-      exit 0
-      ;;
-    *) echo "Unknown option: $arg" >&2; exit 1 ;;
-  esac
-done
-
-file_path=$(notes new-todo "${args[@]}")
+file_path=$(notes new-todo "$@")
 echo "$file_path"
 
-$VISUAL_EDITOR "$NOTES_PATH" "$file_path" &
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "${NOTES_PATH:-$HOME/Dropbox/Notes}" "$file_path" &
 disown

--- a/bin/new-todo
+++ b/bin/new-todo
@@ -7,7 +7,7 @@ if ! command -v notes &>/dev/null; then
   exit 1
 fi
 
-file_path=$(notes new-todo "$@")
+file_path=$(notes new-todo)
 echo "$file_path"
 
 ${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "${NOTES_PATH:-$HOME/Dropbox/Notes}" "$file_path" &


### PR DESCRIPTION
Rewrite six Ruby scripts (new-note, new-todo, latest-todo, latest-note, latest-backlog, latest-weekly) as thin Bash wrappers around the `notes` CLI tool. Removes ~250 lines of duplicated note creation, ID management, and file discovery logic that now lives in the CLI. Each script checks for CLI availability and exits with an informative error if missing.