### PR TITLE
Add mise config to dotfiles management

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,0 +1,6 @@
+[tools]
+node = "24"
+ruby = "3.3.10"
+
+[settings]
+idiomatic_version_file_enable_tools = ["ruby"]

--- a/config/mise/settings.toml
+++ b/config/mise/settings.toml
@@ -1,0 +1,1 @@
+trusted_config_paths = ["~/.dotfiles"]

--- a/dotfiles.json
+++ b/dotfiles.json
@@ -109,5 +109,9 @@
   ],
   "hammerspoon": [
     "~/.hammerspoon/init.lua"
+  ],
+  "mise": [
+    "~/.config/mise/config.toml",
+    "~/.config/mise/settings.toml"
   ]
 }


### PR DESCRIPTION
Adds mise configuration files to dotfiles management via the dotfiles sync script.

**Changes:**
- `config/mise/settings.toml`: New file with `trusted_config_paths = ["~/.dotfiles"]` to auto-trust all `.mise.toml` files in the dotfiles directory
- `config/mise/config.toml`: Snapshot of existing mise tool configuration  
- `dotfiles.json`: Updated to manage both mise config files

After merging, run `dotfiles load` to deploy the settings file to `~/.config/mise/settings.toml`. Mise will then automatically trust any `.mise.toml` files in `~/.dotfiles` and its subdirectories without prompting.