### PR TITLE
Rename dotfiles load command to apply

### DIFF
--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -267,7 +267,7 @@ parser = OptionParser.new do |opts|
   opts.separator ""
   opts.separator "Commands:"
   opts.separator "  save        Copy local environment configuration to dotfiles"
-  opts.separator "  load        Load dotfiles configuration to local environment"
+  opts.separator "  apply       Apply dotfiles configuration to local environment"
   opts.separator "  status      Show status of managed files"
   opts.separator "  config      Show configuration mapping as JSON"
   opts.separator ""
@@ -305,13 +305,13 @@ if ARGV.empty?
 end
 
 command = ARGV[0]
-direction = command == "load" ? :load : :save
+direction = %w[load apply].include?(command) ? :load : :save
 config_files, prune_meta = load_configuration(direction: direction)
 
 case command
 when "save"
   save_dotfiles(config_files, prune_meta, **options)
-when "load"
+when "apply", "load"
   load_dotfiles(config_files, prune_meta, **options)
 when "ls", "status"
   show_status(config_files)

--- a/config/claude/skills/dotfiles/SKILL.md
+++ b/config/claude/skills/dotfiles/SKILL.md
@@ -58,12 +58,12 @@ dotfiles save -v       # Verbose output
 dotfiles save -p       # Prune removed files from dotfiles
 ```
 
-**Load (dotfiles → local)**:
+**Apply (dotfiles → local)**:
 ```bash
-dotfiles load          # Restore configs from dotfiles repo
-dotfiles load -n       # Dry run
-dotfiles load -v       # Verbose output
-dotfiles load -p       # Prune removed files from local
+dotfiles apply          # Apply configs from dotfiles repo to local
+dotfiles apply -n       # Dry run
+dotfiles apply -v       # Verbose output
+dotfiles apply -p       # Prune removed files from local
 ```
 
 **Status**:
@@ -99,11 +99,11 @@ dotfiles config        # Show configuration mapping as JSON
 
 **Save**: `dotfiles save -v` (optionally check `dotfiles status` first)
 
-**Load**: `dotfiles load -v` (optionally check `dotfiles status` first)
+**Apply**: `dotfiles apply -v` (optionally check `dotfiles status` first)
 
 **Push/Pull**: Git operations on `~/.dotfiles` repo
 - **Push** (optionally after save): `cd ~/.dotfiles && git add . && git commit -m "..." && git push`
-- **Pull** (optionally before load): `cd ~/.dotfiles && git pull`
+- **Pull** (optionally before apply): `cd ~/.dotfiles && git pull`
 
 ## Usage Guidelines
 

--- a/setup
+++ b/setup
@@ -32,8 +32,8 @@ else
 fi
 
 if [ -f ~/.dotfiles/bin/dotfiles ]; then
-    echo "Loading dotfiles..."
-    bash ~/.dotfiles/bin/dotfiles load
+    echo "Applying dotfiles..."
+    bash ~/.dotfiles/bin/dotfiles apply
 else
     echo "Warning: dotfiles script not found at ~/.dotfiles/bin/dotfiles"
 fi


### PR DESCRIPTION
Changes the command name from implicit "load/save" to explicit "save/apply", making sync direction immediately clear. The "apply" command means "apply repo configs to local", while "save" means "save local configs to repo".

Maintains "load" as a hidden alias for backwards compatibility. Updates help text in the CLI, SKILL.md documentation, and setup script.