### PR TITLE
Refactor notes skill: split CLI from format spec

### DIFF
--- a/config/claude/skills/notes/FORMAT.md
+++ b/config/claude/skills/notes/FORMAT.md
@@ -1,0 +1,36 @@
+# Notes Archive Format
+
+Detailed format specification for direct file access. Only needed when the `notes` CLI is insufficient.
+
+## Directory Structure
+
+**Hierarchy**: `$NOTES_PATH/YYYY/MM/YYYYMMDD_ID[_slug].md`
+
+**Examples**:
+- `2026/01/20260106_8823.md` — no slug
+- `2026/01/20260102_8814_todo.md` — with slug
+- `2024/12/20241203_6973_disable-letter_opener.md` — descriptive slug
+
+**ID Tracking**: Sequential IDs stored in `$NOTES_PATH/id.json`
+
+## YAML Frontmatter
+
+Optional block at the top of each note:
+
+```yaml
+---
+title: Note title
+tags: [tag1, tag2, tag3]
+slug: short-name
+description: Brief description
+---
+```
+
+## Task Syntax
+
+Used in `*_todo.md` notes:
+
+- `[+]` — Completed
+- `[>]` — Moved to future date
+- `[ ]` — Pending
+- `[daily]` — Tag for daily recurring tasks

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -5,48 +5,22 @@ description: Create and access notes in date-based archive. Create notes with au
 
 # Notes Skill
 
-## Archive Structure
+Use the `notes` CLI tool for all note operations. All commands respect `$NOTES_PATH` or `--path`.
 
-**Location**: `$NOTES_PATH` (defaults to `~/Dropbox/Notes` if not set)
+## Basics
 
-**Directory Hierarchy**: `YYYY/MM/YYYYMMDD_ID[_slug].md`
+- **Location**: `$NOTES_PATH` (defaults to `~/Dropbox/Notes` if not set)
+- **Directory pattern**: `YYYY/MM/YYYYMMDD_ID[_slug].md`
+- **UID**: `YYYYMMDD_ID` uniquely identifies each note
 
-**Examples**:
-- `2026/01/20260106_8823.md` - no slug
-- `2026/01/20260102_8814_todo.md` - with slug
-- `2024/12/20241203_6973_disable-letter_opener.md` - descriptive slug
+## Frontmatter Guidelines
 
-**ID Tracking**: Sequential IDs stored in `$NOTES_PATH/id.json`
-
-**UID (Unique Identifier)**: `YYYYMMDD_ID` uniquely identifies each note
-
-## File Format
-
-**YAML Frontmatter (Optional)**:
-```yaml
----
-title: Note title
-tags: [tag1, tag2, tag3]
-slug: short-name
-description: Brief description
----
-```
-
-**Frontmatter rules**:
 - Only include fields that are explicitly requested or clearly applicable
 - Do NOT add a `date` field — date is already encoded in the filename
-- Add `description` when there is clear context behind the note (e.g., responding to a message, capturing a decision, summarizing a conversation) — use it to record the context/intention, not a summary of the body content
-- If there is no clear context/intention behind the new note, prefer not to include `description` field (avoid generic/non-informative descriptions)
-
-**Task Syntax** (in `*_todo.md` notes):
-- `[+]` - Completed
-- `[>]` - Moved to future date
-- `[ ]` - Pending
-- `[daily]` - Tag for daily recurring tasks
+- Add `description` when there is clear context behind the note (e.g., responding to a message, capturing a decision) — use it to record the context/intention, not a summary of the body content
+- If there is no clear context/intention, omit the `description` field
 
 ## CLI Reference
-
-The `notes` CLI tool handles all note operations. All commands respect `$NOTES_PATH` or `--path`.
 
 ### Create
 
@@ -87,10 +61,14 @@ notes filter 8823
 notes filter todo
 ```
 
-### Content search
+### Content Search
 
 Use the Grep tool against `$NOTES_PATH` for content-level searches (tags, active tasks, keywords).
 
 ## Editing Notes
 
 Preserve YAML frontmatter structure when modifying notes. Use UIDs (`YYYYMMDD_ID`) for cross-referencing.
+
+## Advanced: Archive Format Details
+
+For direct file manipulation (custom searches, bulk edits, format-aware processing), see `FORMAT.md` in this skill directory. Only load it when the CLI commands above are insufficient.

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -29,7 +29,7 @@ Use the `notes` CLI tool for all note operations. All commands respect `$NOTES_P
 echo "# Content" | notes new --slug my-slug
 
 # New note with frontmatter
-echo "# Content" | notes new --tag journal --tag idea --description "Context"
+echo "# Content" | notes new --title "Title" --tag journal --tag idea --description "Context"
 
 # Empty note
 notes new
@@ -52,9 +52,16 @@ notes ls --type todo --limit 1
 notes ls --type backlog --limit 1
 notes ls --type weekly --limit 1
 
+# Path to latest note (optionally by type)
+notes latest
+notes latest todo
+
 # Read a note by ID, slug, or filename
 notes read 8823
 notes read todo
+
+# Read without frontmatter
+notes read todo --no-frontmatter
 
 # Find notes matching a fragment
 notes filter 8823


### PR DESCRIPTION
Split the notes skill into two files: SKILL.md focuses on CLI usage with essential basics, while FORMAT.md contains detailed archive structure, file format, and task syntax.

This reduces token load for typical note operations since agents only load FORMAT.md when direct file manipulation is needed.

The frontmatter guidelines remain in SKILL.md to guide CLI usage correctly.