### PR TITLE
Use notes latest command directly in Hammerspoon

### DIFF
--- a/config/hammerspoon/init.lua
+++ b/config/hammerspoon/init.lua
@@ -17,23 +17,35 @@ hs.hotkey.bind({"cmd", "alt"}, "1", function() switchLayout("english") end)
 hs.hotkey.bind({"cmd", "alt"}, "2", function() switchLayout("russian") end)
 
 -- Notes control (Ctrl+Shift)
-local dotfiles = os.getenv("HOME") .. "/.dotfiles/bin/"
-local function run(script)
-  hs.task.new("/bin/zsh", nil, {"-lc", dotfiles .. script}):start()
+local notesPath = os.getenv("NOTES_PATH") or (os.getenv("HOME") .. "/Dropbox/Notes")
+local subl = "/opt/homebrew/bin/subl"
+
+local function openInSubl(filePath)
+  hs.task.new(subl, nil, {"--add", notesPath, filePath}):start()
+end
+
+local function notesRun(args, callback)
+  hs.task.new("/bin/zsh", function(exitCode, stdout, stderr)
+    if exitCode == 0 and callback then
+      callback(stdout:gsub("%s+$", ""))
+    elseif exitCode ~= 0 then
+      print("notes error: " .. (stderr or ""))
+    end
+  end, {"-lc", "notes " .. args}):start()
 end
 
 local noteKeys = {
-  n = "new-note",
-  l = "latest-note",
-  t = "latest-todo",
-  b = "latest-backlog",
-  w = "latest-weekly",
+  n = {cmd = "new"},
+  l = {cmd = "latest"},
+  t = {cmd = "latest todo"},
+  b = {cmd = "latest backlog"},
+  w = {cmd = "latest weekly"},
 }
 
-for key, script in pairs(noteKeys) do
+for key, cfg in pairs(noteKeys) do
   local hk = hs.hotkey.new({"ctrl", "shift"}, key, function()
     print("ctrl+shift+" .. key .. " pressed")
-    run(script)
+    notesRun(cfg.cmd, openInSubl)
   end)
   local ok = hk:enable()
   if ok then


### PR DESCRIPTION
## Summary

- Replace `ls --type <t> --limit 1` with `notes latest <type>` which returns absolute paths
- Simplify `noteKeys` table — remove per-key `openFn` since all commands now return absolute paths
- All hotkeys use `openInSubl` callback directly

## Test plan

- [x] Reload Hammerspoon config
- [x] Test Ctrl+Shift+N (new note)
- [x] Test Ctrl+Shift+L (latest note)
- [x] Test Ctrl+Shift+T (latest todo)
- [x] Test Ctrl+Shift+B (latest backlog)
- [x] Test Ctrl+Shift+W (latest weekly)