### PR TITLE
Fix Hammerspoon notes hotkeys, move env vars to zshenv

### DIFF
--- a/config/hammerspoon/init.lua
+++ b/config/hammerspoon/init.lua
@@ -18,6 +18,7 @@ hs.hotkey.bind({"cmd", "alt"}, "2", function() switchLayout("russian") end)
 
 -- Notes control (Ctrl+Shift)
 local notesPath = os.getenv("NOTES_PATH") or (os.getenv("HOME") .. "/Dropbox/Notes")
+local notes = os.getenv("HOME") .. "/go/bin/notes"
 local subl = "/opt/homebrew/bin/subl"
 
 local function openInSubl(filePath)
@@ -25,13 +26,17 @@ local function openInSubl(filePath)
 end
 
 local function notesRun(args, callback)
-  hs.task.new("/bin/zsh", function(exitCode, stdout, stderr)
+  local cmdArgs = {"--path", notesPath}
+  for word in args:gmatch("%S+") do
+    table.insert(cmdArgs, word)
+  end
+  hs.task.new(notes, function(exitCode, stdout, stderr)
     if exitCode == 0 and callback then
       callback(stdout:gsub("%s+$", ""))
     elseif exitCode ~= 0 then
       print("notes error: " .. (stderr or ""))
     end
-  end, {"-lc", "notes " .. args}):start()
+  end, cmdArgs):start()
 end
 
 local noteKeys = {

--- a/config/zsh/.zshenv
+++ b/config/zsh/.zshenv
@@ -1,0 +1,41 @@
+#
+# Path
+#
+
+if [[ -x "/opt/homebrew/bin/brew" ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+path=(
+  /opt/homebrew/opt/llvm/bin
+  $HOME/.local/bin
+  $HOME/.opencode/bin
+  $HOME/bin
+  $HOME/go/bin
+  $path
+)
+
+typeset -U path
+export PATH
+
+#
+# Env vars
+#
+
+export LC_CTYPE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export VISUAL="subl --wait"
+export EDITOR=nvim
+export GOPATH=$HOME/go
+export HOMEBREW_NO_AUTO_UPDATE=true
+
+if [[ -x "/usr/libexec/java_home" ]]; then
+  export JAVA_HOME=$(/usr/libexec/java_home 2>/dev/null)
+  export ES_JAVA_HOME=$JAVA_HOME
+fi
+
+export NOTES_PATH=~/Dropbox/Notes
+export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git --exclude node_modules'
+export FZF_DEFAULT_OPTS="--reverse --multi"
+
+source ~/.profile

--- a/config/zsh/.zshenv
+++ b/config/zsh/.zshenv
@@ -38,4 +38,4 @@ export NOTES_PATH=~/Dropbox/Notes
 export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git --exclude node_modules'
 export FZF_DEFAULT_OPTS="--reverse --multi"
 
-source ~/.profile
+[[ -r ~/.profile ]] && source ~/.profile

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -4,48 +4,6 @@ if [[ -o interactive ]] && [[ -t 0 ]]; then
 fi
 
 #
-# Path
-#
-
-if [[ -x "/opt/homebrew/bin/brew" ]]; then
-  # Homebrew installed
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-fi
-
-path=(
-  $HOME/.local/bin
-  $HOME/.opencode/bin
-  $HOME/bin
-  $HOME/go/bin
-  $path
-)
-
-typeset -U path
-export PATH
-
-#
-# Env vars
-#
-
-export LC_CTYPE=en_US.UTF-8
-export LANG=en_US.UTF-8
-export VISUAL="subl --wait"
-export EDITOR=nvim
-export GOPATH=$HOME/go
-export HOMEBREW_NO_AUTO_UPDATE=true
-
-if [[ -x "/usr/libexec/java_home" ]]; then
-  export JAVA_HOME=$(/usr/libexec/java_home 2>/dev/null)
-  export ES_JAVA_HOME=$JAVA_HOME
-fi
-
-export NOTES_PATH=~/Dropbox/Notes
-export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git --exclude node_modules'
-export FZF_DEFAULT_OPTS="--reverse --multi"
-
-source ~/.profile
-
-#
 # Aliases
 #
 
@@ -209,10 +167,6 @@ command -v mise >/dev/null && eval "$(mise activate zsh)"
   source "/opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 unsetopt correct_all
-
-# opencode
-export PATH=/Users/alex/.opencode/bin:$PATH
-export PATH="$(brew --prefix llvm)/bin:$PATH"
 
 # Re-enable terminal echo after initialization completes
 if [[ -o interactive ]] && [[ -t 0 ]]; then

--- a/dotfiles.json
+++ b/dotfiles.json
@@ -90,6 +90,7 @@
     "~/.config/zed/keymap.json"
   ],
   "zsh": [
+    "~/.zshenv",
     "~/.zshrc"
   ],
   "claude": [


### PR DESCRIPTION
## Summary

- Fix Hammerspoon notes hotkeys broken after reboot by calling the `notes` binary directly instead of spawning a zsh shell to find it via PATH
- Move PATH and env vars from `.zshrc` to `.zshenv` so non-interactive shells (scripts, GUI apps) see the full environment
- Guard `.profile` source with existence check for safer public dotfiles
- Add `.zshenv` to dotfiles.json

## Context

After reboot, Hammerspoon inherits a minimal launchd environment. The old approach (`/bin/zsh -lc "notes ..."`) failed because `-lc` is login but non-interactive — it sources `.zshenv` and `.zprofile` but not `.zshrc`, where PATH was configured.

## Test plan

- [x] Verified notes hotkeys work after Hammerspoon config reload
- [x] Tested `notes latest` and `notes latest todo` via `hs.task` with direct binary path