### PR TITLE
Add session-report command and update notes skill

### DIFF
--- a/config/claude/commands/session-report.md
+++ b/config/claude/commands/session-report.md
@@ -28,19 +28,8 @@ Drafted Q2 capacity planning spec
 
 ## Step 2: Append to the report note
 
-Try appending to today's existing report note. If no report note exists for today, create one first.
-
 ```bash
-# Create today's report note if needed
-notes latest --slug report
-# If no note found or date doesn't match today, create:
-notes new --slug report --title "Session Report" --tag reports
-```
-
-Then append:
-
-```bash
-echo "- <summary line>" | notes append --slug report
+echo "- <summary line>" | notes append --slug report --create --title "Session Report" --tag reports
 ```
 
 Report what was appended.

--- a/config/claude/commands/session-report.md
+++ b/config/claude/commands/session-report.md
@@ -1,0 +1,46 @@
+---
+description: Append a one-line session summary to today's report note. Creates the note if it doesn't exist.
+---
+
+Append a one-line summary of the current session to today's report note.
+
+## Step 1: Summarize the current session
+
+Produce a **single line** answering "What was done?" in this session.
+
+**Format rules**:
+
+- One line only. No bullet points, no headers.
+- First person, past tense.
+- If the session involved a PR, reference it: `[#123](https://github.com/org/repo/pull/123)`
+- If the session involved a Jira ticket, reference it: `[PROJ-123](https://retailzipline.atlassian.net/browse/PROJ-123)`
+- Always link references to their original URLs using Markdown syntax.
+- **Never assume people's names.** If a name is needed (e.g., PR author for a review), use `gh api` to fetch it. Trust only API output.
+
+**Examples**:
+
+```
+Reviewed [#456](https://github.com/org/repo/pull/456) for Alice
+Opened [PROJ-789](https://retailzipline.atlassian.net/browse/PROJ-789) — migrate auth tokens to secure storage
+Closed [PROJ-101](https://retailzipline.atlassian.net/browse/PROJ-101)
+Drafted Q2 capacity planning spec
+```
+
+## Step 2: Append to the report note
+
+Try appending to today's existing report note. If no report note exists for today, create one first.
+
+```bash
+# Create today's report note if needed
+notes latest --slug report
+# If no note found or date doesn't match today, create:
+notes new --slug report --title "Session Report" --tag reports
+```
+
+Then append:
+
+```bash
+echo "- <summary line>" | notes append --slug report
+```
+
+Report what was appended.

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -47,8 +47,14 @@ notes new-todo --force
 # Append text to a note by ID, slug, or filename
 echo "Additional content" | notes append my-slug
 
-# Append with filters (same repeatable flags as latest)
+# Append with filters
 echo "More text" | notes append --slug report --type note
+
+# Create note if no match found (atomic check-and-create)
+echo "- [ ] Ship feature" | notes append --type todo --create
+
+# Create with frontmatter (--title and --description require --create)
+echo "- First entry" | notes append --slug report --create --title "Session Report"
 ```
 
 ### List and Filter

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -47,7 +47,7 @@ notes new-todo --force
 # Append text to a note by ID, slug, or filename
 echo "Additional content" | notes append my-slug
 
-# Append with filters
+# Append to the latest note matching filters
 echo "More text" | notes append --slug report --type note
 
 # Create note if no match found (atomic check-and-create)

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -47,7 +47,7 @@ notes new-todo --force
 # Append text to a note by ID, slug, or filename
 echo "Additional content" | notes append my-slug
 
-# Append with filters
+# Append with filters (same repeatable flags as latest)
 echo "More text" | notes append --slug report --type note
 ```
 
@@ -82,6 +82,10 @@ notes latest
 notes latest --type todo
 notes latest --slug report
 notes latest --tag journal
+
+# Filters are repeatable (OR within same flag, AND across flags)
+notes latest --slug report --slug todo
+notes latest --type todo --type backlog
 ```
 
 ### Search

--- a/config/claude/skills/notes/SKILL.md
+++ b/config/claude/skills/notes/SKILL.md
@@ -41,16 +41,26 @@ notes new-todo
 notes new-todo --force
 ```
 
+### Append
+
+```bash
+# Append text to a note by ID, slug, or filename
+echo "Additional content" | notes append my-slug
+
+# Append with filters
+echo "More text" | notes append --slug report --type note
+```
+
 ### List and Filter
 
 ```bash
 # List recent notes
 notes ls --limit 10
 
-# List by type
+# List by type, slug, or tag
 notes ls --type todo --limit 1
-notes ls --type backlog --limit 1
-notes ls --type weekly --limit 1
+notes ls --slug report
+notes ls --tag journal --tag idea
 
 # Find notes matching a fragment in ID, slug, or filename
 notes filter 8823
@@ -67,9 +77,11 @@ notes read todo
 # Read without frontmatter
 notes read todo --no-frontmatter
 
-# Path to latest note (optionally by type)
+# Path to latest note (optionally filtered by type, slug, or tag)
 notes latest
-notes latest todo
+notes latest --type todo
+notes latest --slug report
+notes latest --tag journal
 ```
 
 ### Search
@@ -79,6 +91,11 @@ notes latest todo
 notes grep "pattern"
 notes grep -i "case insensitive"
 notes grep -l "files only"
+
+# Search note contents using ripgrep
+notes rg "pattern"
+notes rg -i "case insensitive"
+notes rg -l "files only"
 ```
 
 ### Path


### PR DESCRIPTION
## Summary

- New `/session-report` slash command that appends a one-line session summary to a daily report note (creates the note if it doesn't exist)
- Updated notes skill CLI reference to match current `notes` CLI: added `append` and `rg` commands, fixed `latest` to use `--type`/`--slug`/`--tag` flags, added `--slug`/`--tag` filter examples to `ls`