### PR TITLE
Fix mise trust to use file path instead of directory

### DIFF
--- a/bin/conductor-archive
+++ b/bin/conductor-archive
@@ -3,5 +3,5 @@
 
 # Remove mise trust for this workspace
 if command -v mise &>/dev/null; then
-  mise trust --untrust "$(pwd)" 2>/dev/null
+  mise trust --untrust "$(pwd)/mise.toml" 2>/dev/null
 fi

--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -3,5 +3,5 @@
 
 # Trust mise config in this workspace
 if command -v mise &>/dev/null; then
-  mise trust --quiet "$(pwd)" 2>/dev/null
+  mise trust --quiet "$(pwd)/mise.toml" 2>/dev/null
 fi


### PR DESCRIPTION
## Summary

- `mise trust` requires a file path (e.g. `mise.toml`), not a directory path
- Fixed both `conductor-setup` and `conductor-archive` hooks to pass `$(pwd)/mise.toml` instead of `$(pwd)`
- Without this fix, new Conductor workspaces fail setup with "config files are not trusted" errors