### PR TITLE
Resolve GitHub usernames to real names in session-report

### DIFF
--- a/config/claude/commands/session-report.md
+++ b/config/claude/commands/session-report.md
@@ -40,7 +40,7 @@ notes latest --slug report 2>/dev/null | grep -q "$(date +%Y%m%d)" && echo "EXIS
 If `MISSING`, create a new report note for today:
 
 ```bash
-notes new --slug report --title "Session Report" --tag reports
+echo "EOD Report:\n" | notes new --slug report --title "EOD Report" --tag reports
 ```
 
 ## Step 3: Append to today's report note

--- a/config/claude/commands/session-report.md
+++ b/config/claude/commands/session-report.md
@@ -15,7 +15,10 @@ Produce a **single line** answering "What was done?" in this session.
 - If the session involved a PR, reference it: `[#123](https://github.com/org/repo/pull/123)`
 - If the session involved a Jira ticket, reference it: `[PROJ-123](https://retailzipline.atlassian.net/browse/PROJ-123)`
 - Always link references to their original URLs using Markdown syntax.
-- **Never assume people's names.** If a name is needed (e.g., PR author for a review), use `gh api` to fetch it. Trust only API output.
+- **Never assume or guess people's names from their GitHub username.** When you need a person's real name (e.g., PR author for a review), resolve it as follows:
+  1. Look for `config/engineers.yml` in the current project directory. If the file exists, read it (do not assume its format) and look up the GitHub username. Use the first name if found.
+  2. If the file does not exist or the username is not in it, use `gh api /users/{username}` to fetch the profile name.
+  3. Only use a name you resolved from one of these two sources.
 
 **Examples**:
 
@@ -37,7 +40,7 @@ notes latest --slug report 2>/dev/null | grep -q "$(date +%Y%m%d)" && echo "EXIS
 If `MISSING`, create a new report note for today:
 
 ```bash
-echo "" | notes new --slug report --title "Session Report" --tag reports
+notes new --slug report --title "Session Report" --tag reports
 ```
 
 ## Step 3: Append to today's report note


### PR DESCRIPTION
## Summary
- Updated the session-report skill to resolve GitHub usernames to real first names using a two-step lookup: first check `config/engineers.yml` in the project directory, then fall back to `gh api`.
- Clarified that the file format should not be assumed — read it dynamically.

## Test plan
- [x] Run `/session-report` in a project with `config/engineers.yml` and verify name resolution
- [x] Run `/session-report` in a project without the file and verify `gh api` fallback