### PR TITLE
Fix apply path for single-file entries in subdirectories

### DIFF
--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -27,6 +27,17 @@ def load_configuration(direction: :save)
   expected_dest_files = Set.new
 
   raw_config.each do |dotfile_dir, local_paths|
+    # Compute common local root for this tool's entries to preserve subdirectory structure
+    entry_dirs = local_paths.map do |p|
+      File.dirname(File.expand_path(p.sub(%r{/\*$}, "").sub(%r{/$}, "")))
+    end
+    tool_local_root = entry_dirs.reduce do |acc, dir|
+      until dir.start_with?("#{acc}/") || dir == acc || acc == "/"
+        acc = File.dirname(acc)
+      end
+      acc
+    end
+
     local_paths.each do |local_path|
       expanded_path = File.expand_path(local_path.sub(%r{/\*$}, "").sub(%r{/$}, ""))
       dotfiles_root = File.expand_path("~/.dotfiles/config/#{dotfile_dir}")
@@ -73,9 +84,9 @@ def load_configuration(direction: :save)
           end
         end
       else
-        # Single file - use original behavior
-        src_filename = File.basename(local_path)
-        dotfile_path = File.expand_path("~/.dotfiles/config/#{dotfile_dir}/#{src_filename}")
+        # Single file - preserve subdirectory structure relative to tool root
+        rel_path = expanded_path.sub("#{tool_local_root}/", "")
+        dotfile_path = File.expand_path("~/.dotfiles/config/#{dotfile_dir}/#{rel_path}")
         config_map[expanded_path] = dotfile_path
 
         if direction == :save


### PR DESCRIPTION
## Summary

- `dotfiles apply` was erroring with "Source file not found" for entries like `~/.claude/hooks/session-end-test.sh`
- The script computed dotfile paths using only `File.basename`, losing subdirectory structure (e.g. `hooks/`)
- Fix: compute a per-tool common root from all entries, then resolve single-file paths relative to that root

## Root cause

For a `claude` entry with `~/.claude/hooks/session-end-test.sh`, the script was looking for the dotfile at `config/claude/session-end-test.sh` instead of `config/claude/hooks/session-end-test.sh`.

## Test

`dotfiles apply -n -v` shows 102 files OK, 0 errors — hook files correctly resolve to `config/claude/hooks/`.