### PR TITLE
Show only unsynced files in dotfiles status

### DIFF
--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -236,6 +236,9 @@ def show_status(config_files)
     status = status_text(local_path, dotfile_path)
     puts "#{status.ljust(30)} #{local_path}"
   end
+
+  puts
+  puts "#{unsync.size} unsynced, #{config_files.size} total"
 end
 
 def status_text(local_path, dotfile_path)

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -225,10 +225,14 @@ def load_dotfiles(config_files, prune_meta, dry_run: false, verbose: false, prun
 end
 
 def show_status(config_files)
-  puts "Status of managed files:"
-  puts
+  unsync = config_files.reject { |local_path, dotfile_path| files_equal?(local_path, dotfile_path) }
 
-  config_files.each do |local_path, dotfile_path|
+  if unsync.empty?
+    puts colorize("All files in sync", Colors::GREEN)
+    return
+  end
+
+  unsync.each do |local_path, dotfile_path|
     status = status_text(local_path, dotfile_path)
     puts "#{status.ljust(30)} #{local_path}"
   end

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -227,18 +227,17 @@ end
 def show_status(config_files)
   unsync = config_files.reject { |local_path, dotfile_path| files_equal?(local_path, dotfile_path) }
 
-  if unsync.empty?
-    puts colorize("All files in sync", Colors::GREEN)
-    return
-  end
-
   unsync.each do |local_path, dotfile_path|
     status = status_text(local_path, dotfile_path)
     puts "#{status.ljust(30)} #{local_path}"
   end
 
-  puts
-  puts "#{unsync.size} unsynced, #{config_files.size} total"
+  puts unless unsync.empty?
+  if unsync.empty?
+    puts colorize("#{config_files.size} files in sync", Colors::GREEN)
+  else
+    puts "#{unsync.size} unsynced, #{config_files.size} total"
+  end
 end
 
 def status_text(local_path, dotfile_path)


### PR DESCRIPTION
Like `git status`, only show files that are out of sync. Print a summary message when everything is in sync.