### PR TITLE
Add note:// link commands to Sublime Text plugin

### DIFF
--- a/config/sublimetext/copy_note_link.py
+++ b/config/sublimetext/copy_note_link.py
@@ -1,0 +1,41 @@
+import sublime
+import sublime_plugin
+import os
+import re
+
+FULL_FILENAME_PATTERN = re.compile(r'^(\d{8}_\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
+SHORT_FILENAME_PATTERN = re.compile(r'^\d{8}_(\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
+
+
+class CopyNoteLinkCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        link = self._build_link()
+        if link:
+            sublime.set_clipboard(link)
+            sublime.status_message(f"Copied: {link}")
+        else:
+            sublime.status_message("Current file is not a note")
+
+    def _build_link(self):
+        path = self.view.file_name()
+        if not path:
+            return None
+        match = FULL_FILENAME_PATTERN.match(os.path.basename(path))
+        return f"note://{match.group(1)}" if match else None
+
+
+class CopyShortNoteLinkCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        link = self._build_link()
+        if link:
+            sublime.set_clipboard(link)
+            sublime.status_message(f"Copied: {link}")
+        else:
+            sublime.status_message("Current file is not a note")
+
+    def _build_link(self):
+        path = self.view.file_name()
+        if not path:
+            return None
+        match = SHORT_FILENAME_PATTERN.match(os.path.basename(path))
+        return f"note://{match.group(1)}" if match else None

--- a/config/sublimetext/copy_note_link.sublime-commands
+++ b/config/sublimetext/copy_note_link.sublime-commands
@@ -1,0 +1,10 @@
+[
+  {
+    "caption": "Copy note link",
+    "command": "copy_note_link"
+  },
+  {
+    "caption": "Copy short note link",
+    "command": "copy_short_note_link"
+  }
+]

--- a/config/sublimetext/open_note_reference.py
+++ b/config/sublimetext/open_note_reference.py
@@ -3,57 +3,83 @@ import sublime_plugin
 import os
 import re
 
-class OpenNoteReferenceCommand(sublime_plugin.TextCommand):
-    REFERENCE_PATTERN = r'^\d{8}_[a-zA-Z0-9_-]+?$'
-    DATE_PATTERN = r'^(\d{8}_\d+)(_[a-zA-Z0-9_-]+)?$'
+TOKEN_PATTERN = re.compile(r'(note://)?([\w-]+)')
+FULL_ID_PATTERN = re.compile(r'^(\d{8}_\d+)(?:_[a-zA-Z0-9_-]+)?$')
+SHORT_ID_PATTERN = re.compile(r'^\d+$')
+FILENAME_FULL_PATTERN = re.compile(r'^(\d{8}_\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
+FILENAME_SHORT_PATTERN = re.compile(r'^\d{8}_(\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
 
+NOTES_ROOT = "~/Dropbox/Notes/"
+
+
+class OpenNoteReferenceCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         for region in self.view.sel():
-            word = self.view.word(region) if region.empty() else region
-            selected_word = self.view.substr(word)
-
-            if not re.match(self.REFERENCE_PATTERN, selected_word):
-                print(f"selected word is not a note reference: '{selected_word}'")
+            token = self._extract_token(region)
+            if not token:
                 continue
 
-            reference = selected_word.strip("[]")
-            referenced_file = self._find_referenced_file(reference)
+            has_scheme, ident = token
+            referenced_file = self._find_referenced_file(has_scheme, ident)
 
             if referenced_file:
-                print(f"opening note reference: {reference} -> {referenced_file}")
+                print(f"opening note reference: {ident} -> {referenced_file}")
                 self.view.window().open_file(referenced_file)
             else:
-                sublime.status_message(f"referenced note not found: {reference}")
+                sublime.status_message(f"referenced note not found: {ident}")
 
-    def _find_referenced_file(self, reference):
+    def _extract_token(self, region):
+        if not region.empty():
+            raw = self.view.substr(region).strip().strip("[]")
+            scheme_match = TOKEN_PATTERN.fullmatch(raw)
+            if scheme_match:
+                return (scheme_match.group(1) is not None, scheme_match.group(2))
+            return None
+
+        line_region = self.view.line(region)
+        line_text = self.view.substr(line_region)
+        cursor_col = region.begin() - line_region.begin()
+
+        for match in TOKEN_PATTERN.finditer(line_text):
+            if match.start() <= cursor_col <= match.end():
+                return (match.group(1) is not None, match.group(2))
+        return None
+
+    def _find_referenced_file(self, has_scheme, ident):
         root_path = self._notes_root_path()
-
         if not root_path:
-            return
+            return None
 
-        match = re.match(self.DATE_PATTERN, reference)
+        full = FULL_ID_PATTERN.match(ident)
+        if full:
+            prefix = full.group(1)
+            for root, _, files in os.walk(root_path):
+                for name in files:
+                    if name.startswith(prefix) and FILENAME_FULL_PATTERN.match(name):
+                        return os.path.join(root, name)
+            return None
 
-        if match:
-            note_id = match.group(1)
-
-            for root, dirs, files in os.walk(root_path):
-                for file in files:
-                    if file.startswith(note_id) and file.endswith(".md"):
-                        return os.path.join(root, file)
+        if has_scheme and SHORT_ID_PATTERN.match(ident):
+            for root, _, files in os.walk(root_path):
+                for name in files:
+                    match = FILENAME_SHORT_PATTERN.match(name)
+                    if match and match.group(1) == ident:
+                        return os.path.join(root, name)
+            return None
 
         return None
 
     def _notes_root_path(self):
         current_file = self.view.file_name()
-
         if not current_file:
             sublime.error_message("Please save the file first.")
-            return
+            return None
+        return os.path.expanduser(NOTES_ROOT)
 
-        return os.path.expanduser("~/Dropbox/Notes/")
 
 def plugin_loaded():
     sublime.status_message("Referenced Note Opener plugin loaded")
+
 
 def plugin_unloaded():
     sublime.status_message("Referenced Note Opener plugin unloaded")

--- a/dotfiles.json
+++ b/dotfiles.json
@@ -33,6 +33,8 @@
     "~/Library/Application Support/Sublime Text/Packages/User/base16-eighties-custom.sublime-color-scheme",
     "~/Library/Application Support/Sublime Text/Packages/User/copy_name.py",
     "~/Library/Application Support/Sublime Text/Packages/User/copy_name.sublime-commands",
+    "~/Library/Application Support/Sublime Text/Packages/User/copy_note_link.py",
+    "~/Library/Application Support/Sublime Text/Packages/User/copy_note_link.sublime-commands",
     "~/Library/Application Support/Sublime Text/Packages/User/Default (Linux).sublime-keymap",
     "~/Library/Application Support/Sublime Text/Packages/User/Default (OSX).sublime-keymap",
     "~/Library/Application Support/Sublime Text/Packages/User/Default (Windows).sublime-keymap",


### PR DESCRIPTION
## Summary
- Add `copy_note_link` (copies `note://YYYYMMDD_NNNN`) and `copy_short_note_link` (copies `note://NNNN`) commands.
- Update `open_note_reference` (Ctrl+O) to accept `note://YYYYMMDD_NNNN`, `note://NNNN`, and legacy bare `YYYYMMDD_NNNN`.
- Short numeric IDs require the `note://` prefix to avoid ambiguity with plain numbers.

Schema choice: `note://` (singular) matches URI convention for single-resource schemes (`http`, `file`, `mailto`, `slack`, `vscode`).
