### PR TITLE
Add copy note ID command and standardize command captions

### DIFF
--- a/config/sublimetext/copy_note_link.py
+++ b/config/sublimetext/copy_note_link.py
@@ -39,3 +39,20 @@ class CopyShortNoteLinkCommand(sublime_plugin.TextCommand):
             return None
         match = SHORT_FILENAME_PATTERN.match(os.path.basename(path))
         return f"note://{match.group(1)}" if match else None
+
+
+class CopyNoteIdCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        note_id = self._note_id()
+        if note_id:
+            sublime.set_clipboard(note_id)
+            sublime.status_message(f"Copied: {note_id}")
+        else:
+            sublime.status_message("Current file is not a note")
+
+    def _note_id(self):
+        path = self.view.file_name()
+        if not path:
+            return None
+        match = FULL_FILENAME_PATTERN.match(os.path.basename(path))
+        return match.group(1) if match else None

--- a/config/sublimetext/copy_note_link.sublime-commands
+++ b/config/sublimetext/copy_note_link.sublime-commands
@@ -6,5 +6,9 @@
   {
     "caption": "Copy short note link",
     "command": "copy_short_note_link"
+  },
+  {
+    "caption": "Copy note id",
+    "command": "copy_note_id"
   }
 ]

--- a/config/sublimetext/copy_note_link.sublime-commands
+++ b/config/sublimetext/copy_note_link.sublime-commands
@@ -1,14 +1,14 @@
 [
   {
-    "caption": "Copy note link",
+    "caption": "Note: Copy link",
     "command": "copy_note_link"
   },
   {
-    "caption": "Copy short note link",
+    "caption": "Note: Copy short link",
     "command": "copy_short_note_link"
   },
   {
-    "caption": "Copy note id",
+    "caption": "Note: Copy id",
     "command": "copy_note_id"
   }
 ]

--- a/config/sublimetext/notes_browser.sublime-commands
+++ b/config/sublimetext/notes_browser.sublime-commands
@@ -1,6 +1,6 @@
 [
   {
-    "caption": "Notes Browser",
+    "caption": "Note: Browse notes",
     "command": "notes_browser"
   }
 ]


### PR DESCRIPTION
## Summary
This PR adds a new command to copy note IDs to the clipboard and standardizes the naming convention for all note-related commands in Sublime Text.

## Key Changes
- **New `CopyNoteIdCommand`**: Added a new command that extracts and copies the note ID from the current file to the clipboard, with appropriate user feedback via status messages
- **Standardized command captions**: Updated all note-related command captions to follow a consistent "Note: [action]" naming pattern for better organization in the command palette
  - "Copy note link" → "Note: Copy link"
  - "Copy short note link" → "Note: Copy short link"
  - "Notes Browser" → "Note: Browse notes"
- **Updated command definitions**: Registered the new `copy_note_id` command in the sublime-commands configuration

## Implementation Details
- The `CopyNoteIdCommand` follows the same pattern as existing note commands, using `FULL_FILENAME_PATTERN` to extract the note ID from the file path
- Provides user feedback through status messages for both success (showing the copied ID) and failure (when the file is not a note) cases
- The standardized caption prefix "Note:" groups all related commands together in the command palette for improved discoverability

https://claude.ai/code/session_013hyfkVSHtcBNhcCDMKDf3u