### PR TITLE
Add codex backend to autocommit

### DIFF
--- a/bin/autocommit
+++ b/bin/autocommit
@@ -3,12 +3,26 @@
 # Backend: --codex (default) or --claude.
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: autocommit [--codex|--claude] [-h|--help]
+
+Stage all changes and commit with an AI-generated message.
+
+Options:
+  --codex     Use codex CLI (default)
+  --claude    Use claude CLI (haiku)
+  -h, --help  Show this help and exit
+EOF
+}
+
 backend=codex
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --claude) backend=claude; shift ;;
     --codex)  backend=codex;  shift ;;
-    *) echo "Unknown option: $1" >&2; exit 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
 

--- a/bin/autocommit
+++ b/bin/autocommit
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+backend=codex
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --claude) backend=claude; shift ;;
+    --codex)  backend=codex;  shift ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
 git add -A
 
 if git diff --cached --quiet; then
@@ -8,7 +17,18 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-msg=$(git diff --cached | claude --model haiku --print \
-  "Here is a git diff. Output ONLY a short meaningful commit message — nothing else, no quotes, no explanation.")
+prompt="Here is a git diff. Output ONLY a short meaningful commit message — nothing else, no quotes, no explanation."
+
+case "$backend" in
+  claude)
+    msg=$(git diff --cached | claude --model haiku --print "$prompt")
+    ;;
+  codex)
+    out=$(mktemp)
+    trap 'rm -f "$out"' EXIT
+    git diff --cached | codex exec --color never --output-last-message "$out" "$prompt" >/dev/null
+    msg=$(cat "$out")
+    ;;
+esac
 
 git commit -m "$msg"

--- a/bin/autocommit
+++ b/bin/autocommit
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Stage all changes and commit with an AI-generated message.
+# Backend: --codex (default) or --claude.
 set -euo pipefail
 
 backend=codex

--- a/bin/publish-notes
+++ b/bin/publish-notes
@@ -6,13 +6,11 @@ if ! command -v notespub &>/dev/null; then
   command -v notespub &>/dev/null || { echo "notespub installed but not on PATH — add \$GOPATH/bin to your PATH"; exit 1; }
 fi
 
-NOTESPUB_CONFIG="${NOTESPUB_CONFIG:-$NOTES_PATH/notespub.yml}" notespub build &&
+NOTESPUB_CONFIG="${NOTESPUB_CONFIG:-$NOTES_PATH/notespub.yml}" notespub build --out=~/src/alexmusayev.com &&
 cd ~/src/alexmusayev.com &&
 git status &&
 git add . &&
 git commit -m "Autocommit pages update" &&
 
 git push origin main &&
-echo &&
-echo https://github.com/dreikanter/alexmusayev.com/actions &&
-open https://github.com/dreikanter/alexmusayev.com/actions
+echo Done


### PR DESCRIPTION
## Summary
- Add `--claude` / `--codex` flags to `bin/autocommit`; `--codex` is the default
- Codex path uses `codex exec --output-last-message` to capture the model's reply cleanly

## Test plan
- [x] `autocommit` (no flag) generates a commit via codex
- [x] `autocommit --codex` generates a commit via codex
- [x] `autocommit --claude` generates a commit via claude haiku
- [x] Unknown flag exits 2 with an error