### PR TITLE
Add Sublime Text integration for notes CLI

### DIFF
--- a/config/sublimetext/new_note.py
+++ b/config/sublimetext/new_note.py
@@ -1,0 +1,55 @@
+import sublime
+import sublime_plugin
+import os
+import shutil
+import subprocess
+
+
+def _notes_binary():
+    gopath = os.environ.get('GOPATH') or os.path.expanduser('~/go')
+    candidate = os.path.join(gopath, 'bin', 'notes')
+    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+    return shutil.which('notes')
+
+
+def _run_notes(args):
+    binary = _notes_binary()
+    if not binary:
+        sublime.error_message("'notes' CLI not found. Install it first.")
+        return None
+
+    env = os.environ.copy()
+    env['PATH'] = env.get('PATH', '') + ':/opt/homebrew/bin:/usr/local/bin'
+
+    try:
+        result = subprocess.run(
+            [binary] + args,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        sublime.error_message(f"notes {' '.join(args)} failed:\n{e.stderr.strip() or e.stdout.strip()}")
+        return None
+
+    path = result.stdout.strip()
+    if not path:
+        sublime.error_message(f"notes {' '.join(args)} returned no path")
+        return None
+    return path
+
+
+class NewNoteCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        path = _run_notes(['new'])
+        if path:
+            self.window.open_file(path)
+
+
+class NewTodoCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        path = _run_notes(['new-todo'])
+        if path:
+            self.window.open_file(path)

--- a/config/sublimetext/new_note.sublime-commands
+++ b/config/sublimetext/new_note.sublime-commands
@@ -1,0 +1,10 @@
+[
+  {
+    "caption": "Note: New note",
+    "command": "new_note"
+  },
+  {
+    "caption": "Note: New todo",
+    "command": "new_todo"
+  }
+]


### PR DESCRIPTION
## Summary
Add Sublime Text plugin integration to create new notes and todos using the `notes` CLI tool directly from the editor.

## Changes
- **new_note.py**: New Sublime Text plugin module that provides:
  - `_notes_binary()`: Locates the `notes` CLI binary by checking `$GOPATH/bin` first, then falling back to system PATH
  - `_run_notes()`: Executes `notes` CLI commands with proper error handling and environment setup (includes Homebrew paths for macOS compatibility)
  - `NewNoteCommand`: Window command to create a new note and open it in the editor
  - `NewTodoCommand`: Window command to create a new todo and open it in the editor

- **new_note.sublime-commands**: Command palette definitions for the two new commands:
  - "Note: New note" - creates a new note
  - "Note: New todo" - creates a new todo

## Implementation Details
- The plugin intelligently locates the `notes` binary by checking `$GOPATH/bin` first (for Go-based installations), then using system `PATH`
- Subprocess execution includes enhanced PATH configuration for macOS (Homebrew paths) to ensure the binary is found in common installation locations
- Comprehensive error handling with user-friendly Sublime Text error dialogs for missing binary, command failures, and empty responses
- Commands are accessible via Sublime Text's command palette

https://claude.ai/code/session_01FgJyiYcou3e9qf89TExwJc