### PR TITLE
Land cursor at EOF when opening new notes

### DIFF
--- a/bin/new-note
+++ b/bin/new-note
@@ -5,5 +5,5 @@ set -euo pipefail
 NOTES="${GOPATH:-$HOME/go}/bin/notes"
 file_path="$("$NOTES" new)"
 
-${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "$(dirname "$(dirname "$(dirname "$file_path")")")" "$file_path" &
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "$(dirname "$(dirname "$(dirname "$file_path")")")" "$file_path:999999" &
 disown

--- a/bin/new-todo
+++ b/bin/new-todo
@@ -10,5 +10,5 @@ fi
 file_path=$(notes new-todo)
 echo "$file_path"
 
-${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "${NOTES_PATH:-$HOME/Dropbox/Notes}" "$file_path" &
+${NOTES_EDITOR:-/opt/homebrew/bin/subl --add} "${NOTES_PATH:-$HOME/Dropbox/Notes}" "$file_path:999999" &
 disown

--- a/config/sublimetext/extract_note.py
+++ b/config/sublimetext/extract_note.py
@@ -39,7 +39,7 @@ class ExtractNoteCommand(sublime_plugin.TextCommand):
             f.write("---\n\n")
             f.write(f"{line_content}\n")
 
-        self.view.window().open_file(new_note_file)
+        self.view.window().open_file(f"{new_note_file}:999999:1", sublime.ENCODED_POSITION)
 
     def _get_new_file_path(self, date, note_id):
         year = date[:4]

--- a/config/sublimetext/new_note.py
+++ b/config/sublimetext/new_note.py
@@ -45,11 +45,11 @@ class NewNoteCommand(sublime_plugin.WindowCommand):
     def run(self):
         path = _run_notes(['new'])
         if path:
-            self.window.open_file(path)
+            self.window.open_file(f"{path}:999999:1", sublime.ENCODED_POSITION)
 
 
 class NewTodoCommand(sublime_plugin.WindowCommand):
     def run(self):
         path = _run_notes(['new-todo'])
         if path:
-            self.window.open_file(path)
+            self.window.open_file(f"{path}:999999:1", sublime.ENCODED_POSITION)


### PR DESCRIPTION
## Summary
- New-note scripts and Sublime extensions now position the cursor on the last line, so typing starts immediately below the frontmatter.
- Updated `bin/new-note`, `bin/new-todo`, and the `NewNote`/`NewTodo`/`ExtractNote` Sublime commands. `bin/journal` inherits the fix via `new-note`.

## Test plan
- [x] Run `new-note` and confirm cursor lands on the last line in Sublime.
- [x] Run `new-todo` and confirm same.
- [x] Trigger `New Note` / `New Todo` from Sublime command palette and confirm same.
- [x] Trigger `Extract Note` on a selected line and confirm cursor lands at EOF in the new file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx3ciUeQAUky8WSzfLwTPC)_