### PR TITLE
Add autocommit-staged script for AI-generated commit messages

### DIFF
--- a/bin/autocommit-staged
+++ b/bin/autocommit-staged
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Commit already-staged files with an AI-generated message.
+# Backend: --codex (default) or --claude.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: autocommit-staged [--codex|--claude] [-h|--help]
+
+Commit already-staged files with an AI-generated message.
+Unlike autocommit, this does NOT stage anything; only what is
+already in the index is committed.
+
+Options:
+  --codex     Use codex CLI (default)
+  --claude    Use claude CLI (haiku)
+  -h, --help  Show this help and exit
+EOF
+}
+
+backend=codex
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --claude) backend=claude; shift ;;
+    --codex)  backend=codex;  shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if git diff --cached --quiet; then
+  echo "Nothing staged to commit."
+  exit 0
+fi
+
+prompt="Here is a git diff. Output ONLY a short meaningful commit message — nothing else, no quotes, no explanation."
+
+case "$backend" in
+  claude)
+    msg=$(git diff --cached | claude --model haiku --print "$prompt")
+    ;;
+  codex)
+    out=$(mktemp)
+    trap 'rm -f "$out"' EXIT
+    git diff --cached | codex exec --color never --output-last-message "$out" "$prompt" >/dev/null
+    msg=$(cat "$out")
+    ;;
+esac
+
+git commit -m "$msg"


### PR DESCRIPTION
## Summary
Add a new `autocommit-staged` script that generates commit messages using AI for already-staged files, without automatically staging additional changes.

## Key Changes
- New executable script `bin/autocommit-staged` that commits staged files with AI-generated messages
- Supports two AI backends: Codex (default) and Claude (haiku model)
- Only commits files already in the git index; does not stage unstaged changes (unlike the existing `autocommit` script)
- Includes command-line options for backend selection (`--codex`, `--claude`) and help (`-h`, `--help`)
- Exits gracefully with a message if nothing is staged

## Implementation Details
- Uses `git diff --cached` to generate the diff for the AI prompt
- Codex backend: Uses temporary file to capture output via `--output-last-message` flag
- Claude backend: Pipes diff directly to `claude` CLI with haiku model
- Includes proper error handling with `set -euo pipefail` and cleanup of temporary files
- Provides clear usage documentation in the help text
