### PR TITLE
Simplify dotfiles skill documentation and standardize across configs

### DIFF
--- a/config/claude/skills/dotfiles/SKILL.md
+++ b/config/claude/skills/dotfiles/SKILL.md
@@ -1,115 +1,29 @@
 ---
 name: dotfiles
-description: Manage dotfiles configuration with bidirectional sync between local environment and ~/.dotfiles repository. Understand the automation script, configuration structure, and common commands.
+description: Conventions for working with the user's personal dotfiles repo at ~/.dotfiles. Use when modifying tracked config files (anything mapped in ~/.dotfiles/dotfiles.json) or when the user mentions "dotfiles".
 ---
 
-# Dotfiles Management Skill
+# Dotfiles
 
-## Overview
+Personal dotfiles repo at `~/.dotfiles`, managed by the [`dotfiles-cli`](https://github.com/dreikanter/dotfiles-cli) tool (`dotfiles` on `$PATH`).
 
-The dotfiles automation provides bidirectional sync between local configuration files and a centralized `~/.dotfiles` repository. Configuration is managed via `dotfiles.json` and the `dotfiles` command.
+For commands and flags, run `dotfiles --help` (and `dotfiles <command> --help`) — it's self-describing. Add `--json` to any command for machine-readable output.
 
-## Structure
+## Mapping
 
-**Repository**: `~/.dotfiles/` (git-tracked)
+`~/.dotfiles/dotfiles.json` maps source paths in `$HOME` to mirrored paths under `~/.dotfiles/config/<tool>/`. Entries are files or directories (trailing `/` = directory, tracked recursively). Adding a file inside an already-mapped directory needs no manifest change — just `save`.
 
-**Key Files**:
-- `dotfiles.json` - Configuration mapping (tool → file paths)
-- `config/` - Organized dotfile storage by tool name
-- `bin/dotfiles` - Ruby automation script (also in `~/bin/dotfiles`)
+## Workflow when editing a tracked file
 
-**Storage Pattern**:
-```
-~/.dotfiles/config/{tool_name}/
-```
+1. Edit the live file in `$HOME` (not the copy under `~/.dotfiles/config/`).
+2. `dotfiles status` — confirm drift.
+3. `dotfiles save` — local → repo. Prefer scoping with `--tool` / `--file` (see `dotfiles save --help`) to avoid touching unrelated drift.
+4. In `~/.dotfiles`, branch and make an **atomic commit**.
 
-Examples:
-- `~/.dotfiles/config/git/.gitconfig`
-- `~/.dotfiles/config/zsh/.zshrc`
-- `~/.dotfiles/config/sublimetext/Preferences.sublime-settings`
+The reverse direction (repo → live) is `dotfiles install`.
 
-## Configuration Format
+## Conventions (not in `--help`)
 
-**File**: `~/.dotfiles/dotfiles.json`
-
-**Structure**:
-```json
-{
-  "tool_name": [
-    "~/path/to/config_file",
-    "~/path/to/directory/*",
-    "~/path/to/directory/"
-  ]
-}
-```
-
-**Path Types**:
-- Single file: `~/.gitconfig`
-- Directory (recursive): `~/.config/nvim/*` or `~/.config/nvim/`
-- Preserves relative directory structure
-
-## Commands
-
-**Save (local → dotfiles)**:
-```bash
-dotfiles save          # Copy local configs to dotfiles repo
-dotfiles save -n       # Dry run (show what would be done)
-dotfiles save -v       # Verbose output
-dotfiles save -p       # Prune removed files from dotfiles
-```
-
-**Apply (dotfiles → local)**:
-```bash
-dotfiles apply          # Apply configs from dotfiles repo to local
-dotfiles apply -n       # Dry run
-dotfiles apply -v       # Verbose output
-dotfiles apply -p       # Prune removed files from local
-```
-
-**Status**:
-```bash
-dotfiles status        # Show sync status of managed files
-# Output: in sync, local changes, dotfile changes, missing, etc.
-```
-
-**Config**:
-```bash
-dotfiles config        # Show configuration mapping as JSON
-```
-
-## Status Indicators
-
-| Status | Meaning | Color |
-|--------|---------|-------|
-| `in sync` | Files match | Green |
-| `local changes` | Local file newer | Red |
-| `dotfile changes` | Dotfile newer | Red |
-| `local copy missing` | Only dotfile exists | Gray |
-| `dotfile missing` | Only local exists | Gray |
-| `neither exists` | Both missing | Red |
-
-## Options
-
-- `-n, --dry-run` - Preview changes without applying
-- `-v, --verbose` - Show detailed file operations
-- `-p, --prune` - Remove destination files missing from source
-- `-h, --help` - Show help message
-
-## Expected Workflows
-
-**Save**: `dotfiles save -v` (optionally check `dotfiles status` first)
-
-**Apply**: `dotfiles apply -v` (optionally check `dotfiles status` first)
-
-**Push/Pull**: Git operations on `~/.dotfiles` repo
-- **Push** (optionally after save): `cd ~/.dotfiles && git add . && git commit -m "..." && git push`
-- **Pull** (optionally before apply): `cd ~/.dotfiles && git pull`
-
-## Usage Guidelines
-
-- Check `dotfiles status` when it makes sense before saving/loading
-- Use dry-run (`-n`) for safety when you consider it necessary
-- Edit `dotfiles.json` to add new config files
-- Config stored in `~/.dotfiles/config/{tool_name}/`
-- The `~/.dotfiles` repo is git-tracked
-- Single source of truth for configuration across machines
+- **Atomic commits, never `git add -A`.** An unscoped `save` syncs every drifted tracked file, so `git status` may surface unrelated changes the user made earlier. Stage only the files for the current logical change — one change per commit.
+- If `install` vs `save` direction is ambiguous (unexpected drift, possible data loss), ask the user which side is authoritative.
+- **No commit attribution.** No `Co-authored-by`, no agent signatures.

--- a/config/pi/skills/dotfiles/SKILL.md
+++ b/config/pi/skills/dotfiles/SKILL.md
@@ -7,7 +7,7 @@ description: Conventions for working with the user's personal dotfiles repo at ~
 
 Personal dotfiles repo at `~/.dotfiles`, managed by the [`dotfiles-cli`](https://github.com/dreikanter/dotfiles-cli) tool (`dotfiles` on `$PATH`).
 
-For commands and flags, run `dotfiles --help` (and `dotfiles <command> --help`) — it's self-describing.
+For commands and flags, run `dotfiles --help` (and `dotfiles <command> --help`) — it's self-describing. Add `--json` to any command for machine-readable output.
 
 ## Mapping
 
@@ -20,8 +20,10 @@ For commands and flags, run `dotfiles --help` (and `dotfiles <command> --help`) 
 3. `dotfiles save` — local → repo. Prefer scoping with `--tool` / `--file` (see `dotfiles save --help`) to avoid touching unrelated drift.
 4. In `~/.dotfiles`, branch and make an **atomic commit**.
 
+The reverse direction (repo → live) is `dotfiles install`.
+
 ## Conventions (not in `--help`)
 
 - **Atomic commits, never `git add -A`.** An unscoped `save` syncs every drifted tracked file, so `git status` may surface unrelated changes the user made earlier. Stage only the files for the current logical change — one change per commit.
-- If `apply` vs `save` direction is ambiguous (unexpected drift, possible data loss), ask the user which side is authoritative.
+- If `install` vs `save` direction is ambiguous (unexpected drift, possible data loss), ask the user which side is authoritative.
 - **No commit attribution.** No `Co-authored-by`, no agent signatures.


### PR DESCRIPTION
## Summary
Streamlined the dotfiles skill documentation to focus on practical conventions and workflows rather than exhaustive command reference. The tool's `--help` is now the source of truth for commands, reducing documentation maintenance burden.

## Key Changes

- **Condensed overview**: Removed verbose "Overview" and "Structure" sections; replaced with concise description pointing to the `dotfiles-cli` tool
- **Simplified command reference**: Removed detailed command tables and flags documentation in favor of directing users to `dotfiles --help` and `dotfiles <command> --help`
- **Clarified workflow**: Streamlined the "Workflow when editing a tracked file" section with numbered steps and clearer direction
- **Added `--json` flag note**: Documented the `--json` output option for machine-readable command output
- **Standardized conventions**: Moved practical guidelines (atomic commits, ambiguity handling, no commit attribution) to a dedicated "Conventions" section
- **Terminology consistency**: Changed `apply` → `install` to match actual CLI command naming
- **Removed redundant sections**: Eliminated "Status Indicators", "Options", "Expected Workflows", and "Usage Guidelines" tables that duplicated `--help` content

## Implementation Details

- Applied the same streamlined structure to both `config/claude/skills/dotfiles/SKILL.md` and `config/pi/skills/dotfiles/SKILL.md` for consistency
- Maintained all essential information while reducing documentation from ~115 lines to ~29 lines
- Preserved the mapping explanation and workflow guidance as these are not self-evident from CLI help
- Emphasized the atomic commit convention as a critical practice not covered by `--help`
