### PR TITLE
Remove CopyNoteLinkCommand and consolidate to short link only

### DIFF
--- a/config/sublimetext/copy_note_link.py
+++ b/config/sublimetext/copy_note_link.py
@@ -3,25 +3,8 @@ import sublime_plugin
 import os
 import re
 
-FULL_FILENAME_PATTERN = re.compile(r'^(\d{8}_\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
 SHORT_FILENAME_PATTERN = re.compile(r'^\d{8}_(\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
-
-
-class CopyNoteLinkCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
-        link = self._build_link()
-        if link:
-            sublime.set_clipboard(link)
-            sublime.status_message(f"Copied: {link}")
-        else:
-            sublime.status_message("Current file is not a note")
-
-    def _build_link(self):
-        path = self.view.file_name()
-        if not path:
-            return None
-        match = FULL_FILENAME_PATTERN.match(os.path.basename(path))
-        return f"note://{match.group(1)}" if match else None
+FULL_FILENAME_PATTERN = re.compile(r'^(\d{8}_\d+)(?:_[a-zA-Z0-9_-]+)?\.md$')
 
 
 class CopyShortNoteLinkCommand(sublime_plugin.TextCommand):

--- a/config/sublimetext/copy_note_link.sublime-commands
+++ b/config/sublimetext/copy_note_link.sublime-commands
@@ -1,10 +1,6 @@
 [
   {
     "caption": "Note: Copy link",
-    "command": "copy_note_link"
-  },
-  {
-    "caption": "Note: Copy short link",
     "command": "copy_short_note_link"
   },
   {


### PR DESCRIPTION
This PR removes the `CopyNoteLinkCommand` class and its associated command registration, consolidating the note link copying functionality to use only the `CopyShortNoteLinkCommand`.
